### PR TITLE
Mapbox streets v6

### DIFF
--- a/styles/basic-v7.json
+++ b/styles/basic-v7.json
@@ -200,15 +200,6 @@
       }
     }
   }, {
-    "id": "country_label_line",
-    "type": "line",
-    "source": "mapbox",
-    "source-layer": "country_label_line",
-    "filter": ["==", "$type", "LineString"],
-    "paint": {
-      "line-color": "#aaa"
-    }
-  }, {
     "id": "country_label",
     "type": "symbol",
     "source": "mapbox",

--- a/styles/basic-v7.json
+++ b/styles/basic-v7.json
@@ -26,7 +26,7 @@
   "sources": {
     "mapbox": {
       "type": "vector",
-      "url": "mapbox://mapbox.mapbox-streets-v6-dev",
+      "url": "mapbox://mapbox.mapbox-streets-v6",
       "maxZoom": 15
     }
   },

--- a/styles/bright-v7.json
+++ b/styles/bright-v7.json
@@ -116,7 +116,7 @@
   "sources": {
     "mapbox": {
       "type": "vector",
-      "url": "mapbox://mapbox.mapbox-streets-v6-dev"
+      "url": "mapbox://mapbox.mapbox-streets-v6"
     }
   },
   "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/bright",

--- a/styles/bright-v7.json
+++ b/styles/bright-v7.json
@@ -779,15 +779,6 @@
       "line-width": "@admin_level_2_width"
     }
   }, {
-    "id": "country_label_line",
-    "type": "line",
-    "source": "mapbox",
-    "source-layer": "country_label_line",
-    "paint": {
-      "line-color": "@text",
-      "line-opacity": 0.5
-    }
-  }, {
     "id": "country_label_1",
     "type": "symbol",
     "source": "mapbox",

--- a/styles/outdoors-v7.json
+++ b/styles/outdoors-v7.json
@@ -1597,19 +1597,6 @@
       "line-color": "#0a1347"
     }
   }, {
-    "id": "country_label_line",
-    "type": "line",
-    "source": "mapbox",
-    "source-layer": "country_label_line",
-    "paint": {
-      "line-color": "@country_text",
-      "line-width": 0.5,
-      "line-opacity": 0.5
-    },
-    "paint.night": {
-      "line-color": "@text_night"
-    }
-  }, {
     "id": "country_label",
     "type": "symbol",
     "source": "mapbox",

--- a/styles/outdoors-v7.json
+++ b/styles/outdoors-v7.json
@@ -185,7 +185,7 @@
   "sources": {
     "mapbox": {
       "type": "vector",
-      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6-dev"
+      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6"
     }
   },
   "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/outdoors",

--- a/styles/pencil-v7.json
+++ b/styles/pencil-v7.json
@@ -19,7 +19,7 @@
   "sources": {
     "mapbox": {
       "type": "vector",
-      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6-dev"
+      "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6"
     }
   },
   "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/pencil",

--- a/styles/satellite-v7.json
+++ b/styles/satellite-v7.json
@@ -46,7 +46,7 @@
   "sources": {
     "mapbox": {
       "type": "vector",
-      "url": "mapbox://mapbox.mapbox-streets-v6-dev"
+      "url": "mapbox://mapbox.mapbox-streets-v6"
     },
     "satellite": {
       "type": "raster",


### PR DESCRIPTION
This updates all the `*-v7.json` styles from mapbox-streets-v6-dev to mapbox-streets-v6. Should I worry about `*-v6.json` or any of the older versions?