### PR TITLE
Change mb-pages demo's css to also track master

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
     <script src='https://mapbox.s3.amazonaws.com/mapbox-gl-js/master/mapbox-gl-dev.js'></script>
     <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
-    <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.6.0/mapbox-gl.css' rel='stylesheet' />
+    <link href='https://mapbox.s3.amazonaws.com/mapbox-gl-js/master/mapbox-gl.css' rel='stylesheet' />
 
     <style>
         body { margin:0; padding:0; }


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox-gl-styles/issues/70#issuecomment-88380167, update the demo to always use the latest `master/mapbox-gl.css` (like is already done with `mapbox-gl-dev.js`).

cc/@peterqliu :sunglasses: