### PR TITLE
Add dark, light, & streets to demo page

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 [
     'basic',
     'bright',
+    'dark',
     'emerald',
     'empty',
+    'light',
+    'mapbox-streets'
     'outdoors',
     'pencil',
     'satellite'


### PR DESCRIPTION
Keeping the [mb-pages demo](https://www.mapbox.com/mapbox-gl-styles/) in sync with repo updates.