### PR TITLE
Actually update demo's styles; fix missing comma

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
     'emerald',
     'empty',
     'light',
-    'mapbox-streets'
+    'mapbox-streets',
     'outdoors',
     'pencil',
     'satellite'

--- a/index.json
+++ b/index.json
@@ -45,8 +45,7 @@
     "sources": {
       "mapbox": {
         "type": "vector",
-        "url": "mapbox://mapbox.mapbox-streets-v6-dev",
-        "maxZoom": 15
+        "url": "mapbox://mapbox.mapbox-streets-v6"
       }
     },
     "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/sprite",
@@ -427,20 +426,6 @@
               ]
             ]
           }
-        }
-      },
-      {
-        "id": "country_label_line",
-        "type": "line",
-        "source": "mapbox",
-        "source-layer": "country_label_line",
-        "filter": [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        "paint": {
-          "line-color": "#aaa"
         }
       },
       {
@@ -1028,7 +1013,7 @@
     "sources": {
       "mapbox": {
         "type": "vector",
-        "url": "mapbox://mapbox.mapbox-streets-v6-dev"
+        "url": "mapbox://mapbox.mapbox-streets-v6"
       }
     },
     "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/bright",
@@ -2061,16 +2046,6 @@
         }
       },
       {
-        "id": "country_label_line",
-        "type": "line",
-        "source": "mapbox",
-        "source-layer": "country_label_line",
-        "paint": {
-          "line-color": "@text",
-          "line-opacity": 0.5
-        }
-      },
-      {
         "id": "country_label_1",
         "type": "symbol",
         "source": "mapbox",
@@ -3018,6 +2993,9652 @@
       }
     ]
   },
+  "dark": {
+    "version": 7,
+    "name": "dark-v7.json",
+    "constants": {
+      "@road-motorway-width": {
+        "base": 1,
+        "stops": [
+          [
+            3,
+            0.5
+          ],
+          [
+            9,
+            1.25
+          ],
+          [
+            20,
+            10
+          ]
+        ]
+      },
+      "@road-width-minor": {
+        "base": 1,
+        "stops": [
+          [
+            14,
+            0.5
+          ],
+          [
+            18,
+            12
+          ]
+        ]
+      },
+      "@sans_md": "Open Sans Semibold, Arial Unicode MS Bold",
+      "@admin-2-boundary": {
+        "base": 1,
+        "stops": [
+          [
+            3,
+            0.5
+          ],
+          [
+            10,
+            2
+          ]
+        ]
+      },
+      "@snow": "#000",
+      "@label-park": "#c2c2c2",
+      "@road-major-width": {
+        "base": 1.4,
+        "stops": [
+          [
+            6,
+            0.5
+          ],
+          [
+            20,
+            30
+          ]
+        ]
+      },
+      "@color-1": {
+        "base": 1,
+        "stops": [
+          [
+            0,
+            "#393939"
+          ],
+          [
+            20,
+            "#393939"
+          ]
+        ]
+      },
+      "@road-minor": "#484848",
+      "@road-street-width": {
+        "base": 1.55,
+        "stops": [
+          [
+            4,
+            0.25
+          ],
+          [
+            20,
+            20
+          ]
+        ]
+      },
+      "@rail-track-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            14,
+            4
+          ],
+          [
+            20,
+            8
+          ]
+        ]
+      },
+      "@building-outline": "#444444",
+      "@park": "#1b1b1b",
+      "@rail-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            14,
+            0.5
+          ],
+          [
+            20,
+            1
+          ]
+        ]
+      },
+      "@land": "#111",
+      "@name": "{name_en}",
+      "@road-major": "#484848",
+      "@wood": "#232323",
+      "@number-2": {
+        "base": 1.5,
+        "stops": [
+          [
+            12.5,
+            0.3
+          ],
+          [
+            14,
+            2
+          ],
+          [
+            18,
+            18
+          ]
+        ]
+      },
+      "@sans_bd": "Open Sans Bold, Arial Unicode MS Bold",
+      "@scrub": "#1c1c1c",
+      "@crop": "#131313",
+      "@label-waterway": "#929292",
+      "@main-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            6,
+            0.5
+          ],
+          [
+            18,
+            26
+          ]
+        ]
+      },
+      "@road-high-z-fadein": {
+        "base": 1,
+        "stops": [
+          [
+            5,
+            0
+          ],
+          [
+            5.5,
+            1
+          ]
+        ]
+      },
+      "@sans": "Open Sans Regular, Arial Unicode MS Regular",
+      "@motorway-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            5,
+            0.75
+          ],
+          [
+            18,
+            32
+          ]
+        ]
+      },
+      "@label": "#999999",
+      "@label-halo": "#000",
+      "@grass": "#1a1a1a",
+      "@water": "#2c2c2c",
+      "@state-label": {
+        "base": 1,
+        "stops": [
+          [
+            0,
+            "#969696"
+          ],
+          [
+            20,
+            "#969696"
+          ]
+        ]
+      },
+      "@label-road": "#929292",
+      "@label-secondary": "#b7b8b7",
+      "@building-fill": "#383838",
+      "@street-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            12.5,
+            0.5
+          ],
+          [
+            14,
+            2
+          ],
+          [
+            18,
+            18
+          ]
+        ]
+      },
+      "@path-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            15,
+            1
+          ],
+          [
+            18,
+            4
+          ]
+        ]
+      },
+      "@road-main-width": {
+        "base": 1.4,
+        "stops": [
+          [
+            6,
+            0.25
+          ],
+          [
+            20,
+            25
+          ]
+        ]
+      }
+    },
+    "sources": {
+      "mapbox": {
+        "url": "mapbox://mapbox.mapbox-streets-v6",
+        "type": "vector"
+      },
+      "mapbox://mapbox.mapbox-terrain-v2": {
+        "url": "mapbox://mapbox.mapbox-terrain-v2",
+        "type": "vector"
+      }
+    },
+    "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/light",
+    "glyphs": "mapbox://fontstack/{fontstack}/{range}.pbf",
+    "layers": [
+      {
+        "id": "background",
+        "type": "background",
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "background-color": "@land"
+        }
+      },
+      {
+        "id": "landcover_snow",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "snow"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@snow",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_crop",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "crop"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@crop",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_grass",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "grass"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@grass",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_scrub",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "scrub"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@scrub",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_wood",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "wood"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@wood",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landuse_industrial",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "industrial"
+          ],
+          [
+            "==",
+            "$type",
+            "Polygon"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#000",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landuse_park",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "landuse",
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "park"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@park"
+        }
+      },
+      {
+        "id": "landuse_wood",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "landuse",
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "wood"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#1f1f1f"
+        }
+      },
+      {
+        "id": "hillshade_highlight_bright",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            94
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#000",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0.15
+              ],
+              [
+                17,
+                0.05
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_highlight_med",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            90
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#000",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0.15
+              ],
+              [
+                17,
+                0.05
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_shadow_faint",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            89
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#999999",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                0.06
+              ],
+              [
+                17,
+                0.01
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_shadow_med",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            78
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#999999",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                0.06
+              ],
+              [
+                17,
+                0.01
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_shadow_dark",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            67
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#888888",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                0.06
+              ],
+              [
+                17,
+                0.01
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_shadow_extreme",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            56
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#999",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                0.06
+              ],
+              [
+                17,
+                0.01
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "building",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "building",
+        "minzoom": 15,
+        "paint": {
+          "fill-outline-color": "@building-outline",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0
+              ],
+              [
+                16.5,
+                1
+              ]
+            ]
+          },
+          "fill-antialias": true,
+          "fill-color": "@building-fill"
+        }
+      },
+      {
+        "id": "waterway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "river",
+            "canal"
+          ]
+        ],
+        "paint": {
+          "line-color": "@water",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                0.25
+              ],
+              [
+                20,
+                6
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "waterway_stream",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "stream"
+          ]
+        ],
+        "paint": {
+          "line-color": "@water",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                0.75
+              ],
+              [
+                20,
+                4
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "water",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "water",
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@water"
+        }
+      },
+      {
+        "id": "aeroway_runway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "aeroway",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "type",
+            "runway"
+          ]
+        ],
+        "layout": {
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1.15,
+            "stops": [
+              [
+                11,
+                3
+              ],
+              [
+                20,
+                32
+              ]
+            ]
+          },
+          "line-color": "#000",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                9,
+                0.5
+              ],
+              [
+                11,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "aeroway_taxiway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "aeroway",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "type",
+            "taxiway"
+          ]
+        ],
+        "layout": {
+          "line-join": "miter"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1.15,
+            "stops": [
+              [
+                10,
+                0.25
+              ],
+              [
+                11,
+                1
+              ],
+              [
+                20,
+                8
+              ]
+            ]
+          },
+          "line-color": "#3c3c3c"
+        }
+      },
+      {
+        "id": "tunnel_minor",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "tunnel",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "motorway_link",
+            "street",
+            "street_limited",
+            "service",
+            "driveway",
+            "path"
+          ]
+        ],
+        "paint": {
+          "line-color": "@road-minor",
+          "line-width": "@road-street-width",
+          "line-dasharray": [
+            0.36,
+            0.18
+          ]
+        }
+      },
+      {
+        "id": "tunnel_major",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "tunnel",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "motorway",
+            "main"
+          ]
+        ],
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@road-major-width",
+          "line-dasharray": [
+            0.28,
+            0.14
+          ]
+        }
+      },
+      {
+        "id": "road-path",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                1
+              ],
+              [
+                18,
+                4
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-street-low-zoom",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 11,
+        "maxzoom": 14.1,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                11.5,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-service-driveway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service",
+            "driveway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@road-width-minor"
+        }
+      },
+      {
+        "id": "road-motorway_link",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width"
+        }
+      },
+      {
+        "id": "road-street_limited",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street_limited",
+            ""
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width"
+        }
+      },
+      {
+        "id": "road-street",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 14,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@number-2",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "road-main",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@road-main-width",
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "road-trunk",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "main"
+          ],
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@motorway-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "road-motorway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@motorway-width",
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "road-rail",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "road-rail-tracks",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-track-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge_minor_case",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "motorway_link",
+            "street",
+            "street_limited",
+            "service",
+            "driveway",
+            "path"
+          ]
+        ],
+        "paint": {
+          "line-color": "@land",
+          "line-width": {
+            "base": 1.6,
+            "stops": [
+              [
+                12,
+                0.5
+              ],
+              [
+                20,
+                10
+              ]
+            ]
+          },
+          "line-gap-width": "@road-street-width"
+        }
+      },
+      {
+        "id": "bridge-path",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-minor",
+          "line-width": "@path-width"
+        }
+      },
+      {
+        "id": "bridge-street-low-zoom",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 11,
+        "maxzoom": 14.1,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-minor",
+          "line-width": "@street-width",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                11.5,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge-motorway_link",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 10,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway_link"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-street_limited",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-street",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-main",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "main"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@main-width",
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "bridge-trunk",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "main"
+          ],
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@road-motorway-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-motorway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@road-motorway-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-rail",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "miter",
+          "line-round-limit": 2
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-rail-tracks",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "miter",
+          "line-round-limit": 2
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-track-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-rail-tracks_copy",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "aerialway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "miter",
+          "line-round-limit": 2
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "admin-3-4-boundaries-bg",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "admin_level",
+            3
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "bevel"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                3.5
+              ],
+              [
+                12,
+                6
+              ]
+            ]
+          },
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                0
+              ],
+              [
+                5,
+                0.75
+              ]
+            ]
+          },
+          "line-color": "#000"
+        }
+      },
+      {
+        "id": "admin-2-boundaries-bg",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "admin_level",
+            2
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ],
+          [
+            "==",
+            "disputed",
+            2
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "miter"
+        },
+        "paint": {
+          "line-color": "#000000",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                0
+              ],
+              [
+                4,
+                0.75
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                3.5
+              ],
+              [
+                10,
+                10
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "admin-3-4-boundaries",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "admin_level",
+            3
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "miter"
+        },
+        "paint": {
+          "line-color": "#797979",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                0
+              ],
+              [
+                3,
+                1
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                0.5
+              ],
+              [
+                12,
+                2
+              ]
+            ]
+          },
+          "line-dasharray": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                [
+                  2,
+                  0
+                ]
+              ],
+              [
+                5,
+                [
+                  2,
+                  2,
+                  6,
+                  2
+                ]
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "admin-2-boundaries",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "admin",
+        "minzoom": 1,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "admin_level",
+            2
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ],
+          [
+            "==",
+            "disputed",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "round",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#5f5f5f",
+          "line-opacity": 1,
+          "line-width": "@admin-2-boundary"
+        }
+      },
+      {
+        "id": "country-label-lg",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "country_label",
+        "maxzoom": 12,
+        "filter": [
+          "all",
+          [
+            "in",
+            "scalerank",
+            1,
+            2
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "text-max-size": 18,
+          "text-max-width": 6
+        },
+        "paint": {
+          "text-color": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "#666"
+              ],
+              [
+                10,
+                "#999"
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                1,
+                9
+              ],
+              [
+                5,
+                18
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "country-label-md",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "country_label",
+        "minzoom": 1,
+        "maxzoom": 8,
+        "filter": [
+          "all",
+          [
+            "in",
+            "scalerank",
+            3,
+            4
+          ]
+        ],
+        "layout": {
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "{code}"
+              ],
+              [
+                2,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "text-max-size": 18,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "#444"
+              ],
+              [
+                10,
+                "#888"
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                2,
+                8
+              ],
+              [
+                7,
+                18
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "country-label-sm",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "country_label",
+        "minzoom": 1,
+        "maxzoom": 10,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "scalerank",
+            5
+          ]
+        ],
+        "layout": {
+          "text-field": "{name_en}",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "text-max-size": 18,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "#444"
+              ],
+              [
+                10,
+                "#888"
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                3,
+                8
+              ],
+              [
+                9,
+                18
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "state-label-lg",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "state_label",
+        "minzoom": 3,
+        "maxzoom": 7,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "area",
+            80000
+          ]
+        ],
+        "layout": {
+          "text-transform": "uppercase",
+          "visibility": "visible",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "{abbr}"
+              ],
+              [
+                4,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "text-max-size": 10,
+          "text-letter-spacing": 0.15,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@state-label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                9
+              ],
+              [
+                7,
+                18
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "marine_label_line_1",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "labelrank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-max-width": 15,
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "@name",
+          "text-max-size": 30,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0.4,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                25
+              ],
+              [
+                4,
+                30
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_line_2",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "labelrank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-max-width": 15,
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "@name",
+          "text-max-size": 24,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                14
+              ],
+              [
+                5,
+                24
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_line_3",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "labelrank",
+            3
+          ]
+        ],
+        "layout": {
+          "text-max-width": 15,
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "@name",
+          "text-max-size": 18,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                13
+              ],
+              [
+                5,
+                18
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_line_other",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "labelrank",
+            4,
+            5,
+            6
+          ]
+        ],
+        "layout": {
+          "text-max-width": 15,
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "@name",
+          "text-max-size": 16,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                12
+              ],
+              [
+                6,
+                16
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_point_1",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "==",
+            "labelrank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-max-width": 4,
+          "visibility": "visible",
+          "symbol-placement": "point",
+          "text-field": "@name",
+          "text-max-size": 30,
+          "text-line-height": 1.5,
+          "text-letter-spacing": 0.25,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                1,
+                12
+              ],
+              [
+                4,
+                30
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_point_2",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "==",
+            "labelrank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "visible",
+          "symbol-placement": "point",
+          "text-field": "@name",
+          "text-max-size": 24,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                14
+              ],
+              [
+                5,
+                24
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_point_3",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "==",
+            "labelrank",
+            3
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "visible",
+          "symbol-placement": "point",
+          "text-field": "@name",
+          "text-max-size": 18,
+          "text-line-height": 1.3,
+          "text-letter-spacing": 0.1,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                13
+              ],
+              [
+                5,
+                18
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_point_other",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "in",
+            "labelrank",
+            4,
+            5,
+            6
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "none",
+          "symbol-placement": "point",
+          "text-field": "@name",
+          "text-max-size": 16,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0.1
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                12
+              ],
+              [
+                6,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place_label_city_large_n",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "<=",
+            "scalerank",
+            1
+          ],
+          [
+            "in",
+            "ldir",
+            "N",
+            "NE",
+            "NW",
+            "W"
+          ],
+          [
+            "==",
+            "type",
+            "city"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "@sans_bd",
+          "text-max-width": 5,
+          "text-max-size": 20,
+          "text-transform": "none",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "bottom"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  -0.2
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "symbol-avoid-edges": false
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                4,
+                11
+              ],
+              [
+                10,
+                20
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "place_label_city_large_s",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "<=",
+            "scalerank",
+            1
+          ],
+          [
+            "in",
+            "ldir",
+            "S",
+            "SE",
+            "SW",
+            "E"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "@sans_bd",
+          "text-max-width": 15,
+          "text-max-size": 20,
+          "text-transform": "none",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "top"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  0.1
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                4,
+                11
+              ],
+              [
+                10,
+                20
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "place_label_city_medium_n",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "<=",
+            "scalerank",
+            4
+          ],
+          [
+            ">",
+            "scalerank",
+            1
+          ],
+          [
+            "in",
+            "ldir",
+            "N",
+            "W",
+            "NW",
+            "NE"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-max-width": 10,
+          "text-max-size": 19,
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "bottom"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  -0.2
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                5,
+                11
+              ],
+              [
+                12,
+                19
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "place_label_city_medium_s",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "<=",
+            "scalerank",
+            4
+          ],
+          [
+            ">",
+            "scalerank",
+            1
+          ],
+          [
+            "in",
+            "ldir",
+            "S",
+            "E",
+            "SE",
+            "SW"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-max-width": 10,
+          "text-max-size": 19,
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "top"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  0.1
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                5,
+                11
+              ],
+              [
+                12,
+                19
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "place_label_city_small_n",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            ">",
+            "scalerank",
+            4
+          ],
+          [
+            "in",
+            "ldir",
+            "N",
+            "W",
+            "NW",
+            "NE"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-max-width": 10,
+          "text-max-size": 19,
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "bottom"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  -0.2
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                6,
+                11
+              ],
+              [
+                14,
+                19
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place_label_city_small_s",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            ">",
+            "scalerank",
+            4
+          ],
+          [
+            "in",
+            "ldir",
+            "S",
+            "E",
+            "SE",
+            "SW"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-max-width": 10,
+          "text-max-size": 19,
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "top"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  0.1
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                6,
+                11
+              ],
+              [
+                14,
+                19
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place_label_other",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "minzoom": 8,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "in",
+            "type",
+            "town",
+            "village",
+            "hamlet"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Regular, Arial Unicode MS Bold",
+          "text-max-width": 15,
+          "text-max-size": 18
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                6,
+                10
+              ],
+              [
+                12,
+                13
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place_label_neighborhood",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "minzoom": 12,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "in",
+            "type",
+            "suburb",
+            "neighbourhood"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Bold, Arial Unicode MS Bold",
+          "text-max-width": 7,
+          "text-max-size": 14,
+          "text-letter-spacing": 0.1,
+          "text-transform": "uppercase"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                12,
+                10
+              ],
+              [
+                16,
+                14
+              ]
+            ]
+          },
+          "text-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                0
+              ],
+              [
+                12,
+                0.66
+              ],
+              [
+                13,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "water-label",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "water_label",
+        "minzoom": 5,
+        "maxzoom": 22,
+        "layout": {
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular",
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@state-label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                12
+              ],
+              [
+                18,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-scalerank1",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail",
+            "airport",
+            "airfield",
+            "heliport",
+            "rocket",
+            "park",
+            "golf",
+            "cemetary",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "<=",
+            "scalerank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-size": 14,
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                "{maki}-11"
+              ],
+              [
+                14,
+                "{maki}-17"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label-secondary",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                14
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1
+        }
+      },
+      {
+        "id": "poi-parks-scalerank1",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "park",
+            "golf",
+            "cemetary",
+            "zoo",
+            "campsite",
+            "heliport",
+            "rocket",
+            "park",
+            "golf",
+            "cemetary",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "<=",
+            "scalerank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-size": 14,
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                "{maki}-11"
+              ],
+              [
+                14,
+                "{maki}-17"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label-park",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                14
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1
+        }
+      },
+      {
+        "id": "airport-label",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "airport",
+            "heliport",
+            "rocket"
+          ],
+          [
+            "<=",
+            "scalerank",
+            2
+          ]
+        ],
+        "layout": {
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                12,
+                "{maki-11}"
+              ],
+              [
+                13,
+                "{maki-17}"
+              ]
+            ]
+          },
+          "visibility": "visible",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                12,
+                "{ref}"
+              ],
+              [
+                13,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-max-size": 18,
+          "text-max-width": 9,
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                18
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 0
+        }
+      },
+      {
+        "id": "road-label-large",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "road_label",
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway",
+            "main"
+          ]
+        ],
+        "layout": {
+          "symbol-placement": "line",
+          "text-field": "{name_en}",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-transform": "none",
+          "text-letter-spacing": 0,
+          "text-max-size": 16,
+          "text-padding": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                17
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 2,
+          "text-color": "@label-road"
+        }
+      },
+      {
+        "id": "road-label-med",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "road_label",
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ]
+        ],
+        "layout": {
+          "symbol-placement": "line",
+          "text-field": "{name_en}",
+          "text-font": "@sans_md",
+          "text-transform": "none",
+          "text-letter-spacing": 0,
+          "text-max-size": 16,
+          "text-padding": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                16
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 2,
+          "text-color": "@label-road"
+        }
+      },
+      {
+        "id": "road-label-sm",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "road_label",
+        "minzoom": 12,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "class",
+            "motorway",
+            "main",
+            "street_limited",
+            "street"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "symbol-placement": "line",
+          "text-field": "{name_en}",
+          "text-font": "@sans_md",
+          "text-transform": "none",
+          "text-letter-spacing": 0,
+          "text-max-size": 16,
+          "text-padding": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                15
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 2,
+          "text-color": "@label-road"
+        }
+      },
+      {
+        "id": "waterway-label",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "waterway_label",
+        "minzoom": 12,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "river"
+          ]
+        ],
+        "layout": {
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular",
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "{name_en}"
+        },
+        "paint": {
+          "text-color": "@label-waterway",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                12
+              ],
+              [
+                18,
+                16
+              ]
+            ]
+          }
+        }
+      }
+    ],
+    "owner": "andreasviglakis",
+    "modified": "2015-04-10T21:22:58.363Z",
+    "created": "2015-04-09T00:33:20.278Z",
+    "id": "andreasviglakis.0c9f1222"
+  },
+  "emerald": {
+    "version": 7,
+    "name": "Emerald",
+    "constants": {
+      "@generic_poi": "#766f6f",
+      "@secondary_case_width": {
+        "base": 1,
+        "stops": [
+          [
+            11.25,
+            0.75
+          ],
+          [
+            11.3,
+            1
+          ],
+          [
+            18,
+            13.25
+          ]
+        ]
+      },
+      "@case_dark": "#bcb4b9",
+      "@hillshades": {
+        "base": 1,
+        "stops": [
+          [
+            14,
+            0.05
+          ],
+          [
+            15,
+            0
+          ]
+        ]
+      },
+      "@case_light": "#c5babf",
+      "@color-2": "#fff",
+      "@number-1": {
+        "base": 1,
+        "stops": [
+          [
+            5,
+            0
+          ],
+          [
+            5.2,
+            1
+          ]
+        ]
+      },
+      "@background": "#F8F4F0",
+      "@number-2": 1,
+      "@number-4": {
+        "base": 1,
+        "stops": [
+          [
+            14,
+            "@case_light"
+          ],
+          [
+            14.1,
+            "@case_dark"
+          ]
+        ]
+      },
+      "@motorway_case": "#e59063",
+      "@link_case_width": {
+        "base": 1.05,
+        "stops": [
+          [
+            11.95,
+            0.7
+          ],
+          [
+            12,
+            2.75
+          ],
+          [
+            20,
+            13
+          ]
+        ]
+      }
+    },
+    "sources": {
+      "compositedsource": {
+        "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6",
+        "type": "vector"
+      }
+    },
+    "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/emerald",
+    "glyphs": "mapbox://fontstack/{fontstack}/{range}.pbf",
+    "layers": [
+      {
+        "id": "background",
+        "type": "background",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "background-color": "@background"
+        }
+      },
+      {
+        "id": "landcover_wood",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "wood"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#d4e2c6",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_scrub",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "scrub"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#e0e8cd",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_grass",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "grass"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#e7ebd1",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_crop",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "crop"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#eeeed4",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_snow",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "snow"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#f4f8ff",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "hospital",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "hospital"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#f8ecee",
+          "fill-outline-color": "#ead1d2"
+        }
+      },
+      {
+        "id": "school",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "school"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#e7e3e7",
+          "fill-outline-color": {
+            "base": 1,
+            "stops": [
+              [
+                12,
+                "#f6eeff"
+              ],
+              [
+                13,
+                "#e0dced"
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "park",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "==",
+            "class",
+            "park"
+          ],
+          [
+            "==",
+            "class",
+            "grass"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#d8e1c5",
+          "fill-opacity": 1,
+          "fill-outline-color": "#d2e4c7"
+        }
+      },
+      {
+        "id": "wood",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "wood"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#6a4",
+          "fill-opacity": 0.05
+        }
+      },
+      {
+        "id": "pitch",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "==",
+            "class",
+            "pitch"
+          ],
+          [
+            "==",
+            "type",
+            "golf_course"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#c7d7bf",
+          "fill-opacity": 1
+        }
+      },
+      {
+        "id": "sand",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "sand"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#f1f0d2",
+          "fill-opacity": 1
+        }
+      },
+      {
+        "id": "cemetery",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "cemetery"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#e7ebd1"
+        }
+      },
+      {
+        "id": "shadow_uber",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 15,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            56
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-opacity": "@hillshades",
+          "fill-color": "#031c2a"
+        }
+      },
+      {
+        "id": "shadow_strong",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 15,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            67
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-opacity": "@hillshades",
+          "fill-color": "#031c2a"
+        }
+      },
+      {
+        "id": "shadow_medium",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 15,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            78
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-opacity": "@hillshades",
+          "fill-color": "#031c2a"
+        }
+      },
+      {
+        "id": "shadow_weak",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 15,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            89
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-opacity": "@hillshades",
+          "fill-color": "#031c2a"
+        }
+      },
+      {
+        "id": "highlight_weak",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 15,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            90
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                0.1
+              ],
+              [
+                15,
+                0
+              ]
+            ]
+          },
+          "fill-color": "#fff"
+        }
+      },
+      {
+        "id": "highlight_medium",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            94
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#fff",
+          "fill-opacity": 0.2
+        }
+      },
+      {
+        "id": "airport",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "industrial"
+          ]
+        ],
+        "layout": {},
+        "paint": {
+          "fill-color": "#ddd",
+          "fill-opacity": 0.25
+        }
+      },
+      {
+        "id": "aeroway",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "aeroway",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "runway",
+            "taxiway"
+          ]
+        ],
+        "layout": {
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                2
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          },
+          "line-opacity": 1,
+          "line-color": "#ddd"
+        }
+      },
+      {
+        "id": "water_edge",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "water",
+        "minzoom": 2,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#7d8892",
+          "line-opacity": 1,
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0
+              ],
+              [
+                20,
+                2.5
+              ]
+            ]
+          },
+          "line-blur": 1
+        }
+      },
+      {
+        "id": "water",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "water",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#cadcea",
+          "fill-outline-color": "#cadcea"
+        }
+      },
+      {
+        "id": "barrier_land",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "barrier_line",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "land"
+          ],
+          [
+            "==",
+            "$type",
+            "Polygon"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#F8F4F0",
+          "fill-opacity": 1
+        }
+      },
+      {
+        "id": "railroad",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#bbb",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                5,
+                0.75
+              ],
+              [
+                16,
+                1.5
+              ]
+            ]
+          },
+          "line-opacity": 0.75
+        }
+      },
+      {
+        "id": "railroad_hashes",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#bbb",
+          "line-width": {
+            "base": 1.49,
+            "stops": [
+              [
+                5,
+                0.5
+              ],
+              [
+                16,
+                8
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.15,
+            1.95
+          ],
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "path",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#a0aaa0",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                12,
+                0.5
+              ],
+              [
+                15,
+                1.5
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.3,
+            2.5
+          ],
+          "line-opacity": 0.75
+        }
+      },
+      {
+        "id": "building_walls",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "building",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#cfc4c3",
+          "fill-opacity": 1
+        }
+      },
+      {
+        "id": "building_rooves",
+        "type": "fill",
+        "source": "compositedsource",
+        "source-layer": "building",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                "#F8F4F0"
+              ],
+              [
+                14,
+                "#ede6e3"
+              ]
+            ]
+          },
+          "fill-translate": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                [
+                  0,
+                  0
+                ]
+              ],
+              [
+                19,
+                [
+                  -4,
+                  -4
+                ]
+              ]
+            ]
+          },
+          "fill-opacity": 1
+        }
+      },
+      {
+        "id": "building_roof_edges",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "building",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "#cfc4c3",
+          "line-width": 0.5,
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15.8,
+                0
+              ],
+              [
+                16,
+                1
+              ]
+            ]
+          },
+          "line-translate": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                [
+                  -0.25,
+                  -0.25
+                ]
+              ],
+              [
+                19,
+                [
+                  -4,
+                  -4
+                ]
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "country_border",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "admin_level",
+            2
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#293804",
+          "line-opacity": 0.5,
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                0.5
+              ],
+              [
+                10,
+                2
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "state_border",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "admin_level",
+            4
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#99a472",
+          "line-opacity": 1,
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                0.25
+              ],
+              [
+                13,
+                2
+              ]
+            ]
+          },
+          "line-dasharray": [
+            3,
+            1
+          ]
+        }
+      },
+      {
+        "id": "state-label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "state_label",
+        "minzoom": 3,
+        "maxzoom": 22,
+        "layout": {
+          "text-allow-overlap": true,
+          "text-ignore-placement": false,
+          "text-transform": "uppercase",
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "{abbr}"
+              ],
+              [
+                6,
+                "{name}"
+              ]
+            ]
+          },
+          "text-letter-spacing": 0.15,
+          "text-max-width": 4
+        },
+        "paint": {
+          "text-opacity": 0.25,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                1
+              ],
+              [
+                12,
+                35
+              ]
+            ]
+          },
+          "text-color": "#425807"
+        }
+      },
+      {
+        "id": "tunnel_path",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#aaa",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                5,
+                0.75
+              ],
+              [
+                16,
+                1.5
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.3,
+            2.5
+          ],
+          "line-opacity": 0.75
+        }
+      },
+      {
+        "id": "tunnel_service_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#ccc",
+          "line-width": {
+            "base": 1.75,
+            "stops": [
+              [
+                12,
+                0.25
+              ],
+              [
+                14.5,
+                1.5
+              ],
+              [
+                14.6,
+                4
+              ],
+              [
+                18,
+                8.5
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.5,
+            0.5
+          ],
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "tunnel_street_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@number-4",
+          "line-width": {
+            "base": 1.99,
+            "stops": [
+              [
+                5,
+                0.25
+              ],
+              [
+                14.05,
+                1
+              ],
+              [
+                14.1,
+                4
+              ],
+              [
+                18,
+                9
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.5,
+            0.5
+          ]
+        }
+      },
+      {
+        "id": "tunnel_tertiary_misc_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "type",
+            "primary",
+            "secondary",
+            "trunk"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@number-4",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                11.9,
+                0.75
+              ],
+              [
+                12,
+                3.5
+              ],
+              [
+                18,
+                11
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.5,
+            0.5
+          ]
+        }
+      },
+      {
+        "id": "tunnel_secondary_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "secondary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@number-4",
+          "line-width": "@secondary_case_width",
+          "line-opacity": 1,
+          "line-dasharray": [
+            0.5,
+            0.5
+          ]
+        }
+      },
+      {
+        "id": "tunnel_primary_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "primary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@number-4",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                10.9,
+                1
+              ],
+              [
+                11,
+                2.75
+              ],
+              [
+                18,
+                15
+              ]
+            ]
+          },
+          "line-opacity": 1,
+          "line-dasharray": [
+            0.5,
+            0.5
+          ]
+        }
+      },
+      {
+        "id": "tunnel_trunk_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#dba866",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.95,
+                1.5
+              ],
+              [
+                10,
+                2
+              ],
+              [
+                18,
+                16
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.5,
+            0.5
+          ]
+        }
+      },
+      {
+        "id": "construction_tunnel",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                14.05,
+                0
+              ],
+              [
+                14.1,
+                2
+              ],
+              [
+                18,
+                7
+              ]
+            ]
+          },
+          "line-opacity": 0.25,
+          "line-color": "#ccc",
+          "line-dasharray": [
+            1,
+            0
+          ]
+        }
+      },
+      {
+        "id": "tunnel_service",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                14.5,
+                0
+              ],
+              [
+                14.6,
+                2
+              ],
+              [
+                18,
+                4.5
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "tunnel_street",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.75,
+            "stops": [
+              [
+                14.05,
+                0
+              ],
+              [
+                14.1,
+                2.25
+              ],
+              [
+                18,
+                5
+              ]
+            ]
+          },
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "tunnel_tertiary_misc",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "type",
+            "primary",
+            "secondary",
+            "trunk"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                11.95,
+                0
+              ],
+              [
+                12,
+                2
+              ],
+              [
+                18,
+                7
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "tunnel_secondary",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "secondary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                11.2,
+                0
+              ],
+              [
+                11.3,
+                0.25
+              ],
+              [
+                18,
+                9.5
+              ]
+            ]
+          },
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "tunnel_primary",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "primary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                10.9,
+                0
+              ],
+              [
+                11,
+                1.5
+              ],
+              [
+                18,
+                10
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "tunnel_motorway_link_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@motorway_case",
+          "line-width": "@link_case_width",
+          "line-dasharray": [
+            0.5,
+            0.5
+          ]
+        }
+      },
+      {
+        "id": "tunnel_motorway_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@motorway_case",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                5,
+                1
+              ],
+              [
+                9.95,
+                1
+              ],
+              [
+                10,
+                2.25
+              ],
+              [
+                20,
+                24
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.5,
+            0.5
+          ]
+        }
+      },
+      {
+        "id": "tunnel_trunk",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "trunk"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fea",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.9,
+                0
+              ],
+              [
+                10,
+                0.5
+              ],
+              [
+                18,
+                9
+              ]
+            ]
+          },
+          "line-gap-width": 0,
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "tunnel_motorway_link",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fc8",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.95,
+                0.25
+              ],
+              [
+                10,
+                1
+              ],
+              [
+                18,
+                6
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "tunnel_motorway",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fc8",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.9,
+                0
+              ],
+              [
+                10,
+                1
+              ],
+              [
+                20,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "service_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "@number-4",
+          "line-width": {
+            "base": 1.75,
+            "stops": [
+              [
+                14.55,
+                0.5
+              ],
+              [
+                14.6,
+                3
+              ],
+              [
+                18,
+                7.5
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "street_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "@number-4",
+          "line-width": {
+            "base": 1.99,
+            "stops": [
+              [
+                5,
+                0.25
+              ],
+              [
+                14.05,
+                1
+              ],
+              [
+                14.1,
+                4
+              ],
+              [
+                18,
+                9
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "tertiary_misc_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "type",
+            "primary",
+            "secondary",
+            "trunk"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                11.9,
+                "@case_light"
+              ],
+              [
+                12,
+                "@case_dark"
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                11.95,
+                0.75
+              ],
+              [
+                12,
+                3.5
+              ],
+              [
+                18,
+                11
+              ]
+            ]
+          },
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                5,
+                0
+              ],
+              [
+                5.2,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "secondary_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "secondary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                11.2,
+                "@case_light"
+              ],
+              [
+                11.3,
+                "@case_dark"
+              ]
+            ]
+          },
+          "line-width": "@secondary_case_width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "primary_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "primary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                10.9,
+                "@case_light"
+              ],
+              [
+                11,
+                "@case_dark"
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                10.95,
+                1
+              ],
+              [
+                11,
+                2.75
+              ],
+              [
+                18,
+                15
+              ]
+            ]
+          },
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "trunk_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#dba866",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.95,
+                1.5
+              ],
+              [
+                10,
+                2
+              ],
+              [
+                18,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "construction_road",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                14.05,
+                0
+              ],
+              [
+                14.1,
+                2
+              ],
+              [
+                18,
+                7
+              ]
+            ]
+          },
+          "line-opacity": 0.25,
+          "line-color": "#ccc",
+          "line-dasharray": [
+            1,
+            0
+          ]
+        }
+      },
+      {
+        "id": "service",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                14.55,
+                0
+              ],
+              [
+                14.6,
+                2
+              ],
+              [
+                18,
+                4.5
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "street",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.75,
+            "stops": [
+              [
+                14.05,
+                0
+              ],
+              [
+                14.1,
+                2.75
+              ],
+              [
+                18,
+                6
+              ]
+            ]
+          },
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "tertiary_misc",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "type",
+            "primary",
+            "secondary",
+            "trunk"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                11.95,
+                0
+              ],
+              [
+                12,
+                2.5
+              ],
+              [
+                18,
+                8
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "secondary",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "secondary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                11.2,
+                0
+              ],
+              [
+                11.3,
+                0.5
+              ],
+              [
+                18,
+                10.5
+              ]
+            ]
+          },
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "primary",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "primary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                10.95,
+                0
+              ],
+              [
+                11,
+                2
+              ],
+              [
+                18,
+                12
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "motorway_link_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "@motorway_case",
+          "line-width": "@link_case_width"
+        }
+      },
+      {
+        "id": "motorway_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "@motorway_case",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                5,
+                1
+              ],
+              [
+                9.9,
+                1
+              ],
+              [
+                10,
+                2.25
+              ],
+              [
+                20,
+                24
+              ]
+            ]
+          },
+          "line-opacity": "@number-1"
+        }
+      },
+      {
+        "id": "trunk",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "trunk"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fea",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.95,
+                0
+              ],
+              [
+                10,
+                1.5
+              ],
+              [
+                18,
+                12
+              ]
+            ]
+          },
+          "line-gap-width": 0
+        }
+      },
+      {
+        "id": "motorway_link",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fc8",
+          "line-width": {
+            "base": 1.05,
+            "stops": [
+              [
+                9.95,
+                0
+              ],
+              [
+                10,
+                1
+              ],
+              [
+                20,
+                8.5
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "motorway",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fc8",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.9,
+                0
+              ],
+              [
+                10,
+                1.5
+              ],
+              [
+                20,
+                18
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "river_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "waterway_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "river"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                1
+              ],
+              [
+                20,
+                1.75
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 550,
+          "text-ignore-placement": false,
+          "text-max-angle": 15,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "text-padding": 10,
+          "visibility": "visible",
+          "text-rotation-alignment": "map",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.3,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-color": "#568eb3",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                8
+              ],
+              [
+                18,
+                18
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "ocean_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "<=",
+            "labelrank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                1.25
+              ],
+              [
+                20,
+                1.75
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 550,
+          "text-ignore-placement": false,
+          "text-max-angle": 15,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 10,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.3,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-color": "#568eb3",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                13
+              ],
+              [
+                18,
+                29
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "sea_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "labelrank",
+            3,
+            4,
+            5
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                1.25
+              ],
+              [
+                20,
+                1.75
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 550,
+          "text-ignore-placement": false,
+          "text-max-angle": 15,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 10,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.2,
+          "text-max-width": 7.5
+        },
+        "paint": {
+          "text-color": "#568eb3",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                11
+              ],
+              [
+                18,
+                18
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_service_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#ccc",
+          "line-width": {
+            "base": 1.75,
+            "stops": [
+              [
+                12,
+                0.25
+              ],
+              [
+                14.55,
+                1.5
+              ],
+              [
+                14.6,
+                4
+              ],
+              [
+                18,
+                7
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_street_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                "@case_light"
+              ],
+              [
+                14.1,
+                "@case_dark"
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1.99,
+            "stops": [
+              [
+                5,
+                0.25
+              ],
+              [
+                14.05,
+                1
+              ],
+              [
+                14.1,
+                4
+              ],
+              [
+                18,
+                9
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_tertiary_misc_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "type",
+            "primary",
+            "secondary",
+            "trunk"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                11.9,
+                "@case_light"
+              ],
+              [
+                12,
+                "@case_dark"
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                11.95,
+                0.5
+              ],
+              [
+                12,
+                3.5
+              ],
+              [
+                18,
+                11
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_secondary_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "secondary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                11.2,
+                "@case_light"
+              ],
+              [
+                11.3,
+                "@case_dark"
+              ]
+            ]
+          },
+          "line-width": "@secondary_case_width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge_primary_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "primary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                10.9,
+                "@case_light"
+              ],
+              [
+                11,
+                "@case_dark"
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                10.95,
+                0.75
+              ],
+              [
+                11,
+                2.75
+              ],
+              [
+                18,
+                15
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_trunk_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#dba866",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.9,
+                1.5
+              ],
+              [
+                10,
+                2
+              ],
+              [
+                18,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "construction_bridge",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                12.05,
+                0
+              ],
+              [
+                12.1,
+                2
+              ],
+              [
+                18,
+                7
+              ]
+            ]
+          },
+          "line-opacity": 0.25,
+          "line-color": "#ccc",
+          "line-dasharray": [
+            1,
+            0
+          ]
+        }
+      },
+      {
+        "id": "bridge_service",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                14.5,
+                0
+              ],
+              [
+                14.6,
+                2
+              ],
+              [
+                18,
+                4.5
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_street",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "!=",
+            "type",
+            "construction"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.75,
+            "stops": [
+              [
+                14.05,
+                0
+              ],
+              [
+                14.1,
+                2.75
+              ],
+              [
+                18,
+                6
+              ]
+            ]
+          },
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge_tertiary_misc",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "type",
+            "primary",
+            "secondary",
+            "trunk"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                11.9,
+                0
+              ],
+              [
+                12,
+                2.5
+              ],
+              [
+                18,
+                8
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_secondary",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "secondary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                11.2,
+                0
+              ],
+              [
+                11.3,
+                0.5
+              ],
+              [
+                18,
+                10.5
+              ]
+            ]
+          },
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge_primary",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "primary"
+          ],
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                10.9,
+                0
+              ],
+              [
+                11,
+                2
+              ],
+              [
+                18,
+                12
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_trunk",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fea",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.9,
+                0
+              ],
+              [
+                10,
+                1.5
+              ],
+              [
+                18,
+                12
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_motorway_link_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@motorway_case",
+          "line-width": "@link_case_width"
+        }
+      },
+      {
+        "id": "bridge_motorway_case",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@motorway_case",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                5,
+                1
+              ],
+              [
+                9.95,
+                1
+              ],
+              [
+                10,
+                2.25
+              ],
+              [
+                20,
+                24
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_motorway_link",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fc8",
+          "line-width": {
+            "base": 1.05,
+            "stops": [
+              [
+                9.95,
+                1
+              ],
+              [
+                10,
+                1
+              ],
+              [
+                20,
+                8.5
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_path",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#aaa",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                5,
+                0.75
+              ],
+              [
+                16,
+                1.5
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.3,
+            2.5
+          ],
+          "line-opacity": 0.75
+        }
+      },
+      {
+        "id": "bridge_motorway",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#fc8",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                9.95,
+                0
+              ],
+              [
+                10,
+                1.5
+              ],
+              [
+                20,
+                18
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge_railroad",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#bbb",
+          "line-width": {
+            "base": 1.25,
+            "stops": [
+              [
+                5,
+                0.75
+              ],
+              [
+                16,
+                1.5
+              ]
+            ]
+          },
+          "line-opacity": 0.75
+        }
+      },
+      {
+        "id": "bridge_railroad_hashes",
+        "type": "line",
+        "source": "compositedsource",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#bbb",
+          "line-width": {
+            "base": 1.49,
+            "stops": [
+              [
+                5,
+                0.5
+              ],
+              [
+                16,
+                8
+              ]
+            ]
+          },
+          "line-dasharray": [
+            0.15,
+            1.95
+          ],
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "country_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "country_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-width": 4,
+          "text-transform": "none",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "text-letter-spacing": 0.05,
+          "text-allow-overlap": false,
+          "text-ignore-placement": false
+        },
+        "paint": {
+          "text-opacity": 0.75,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                6
+              ],
+              [
+                10,
+                30
+              ]
+            ]
+          },
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": 2
+        }
+      },
+      {
+        "id": "city_label_big",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "place_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "city"
+          ],
+          [
+            "<=",
+            "scalerank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                1
+              ],
+              [
+                20,
+                1.3
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "dot"
+              ],
+              [
+                5,
+                ""
+              ]
+            ]
+          },
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                4.99,
+                [
+                  0,
+                  0.25
+                ]
+              ],
+              [
+                5,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "text-rotation-alignment": "viewport",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "top"
+              ],
+              [
+                5,
+                "center"
+              ]
+            ]
+          },
+          "text-field": "{name}",
+          "text-letter-spacing": 0,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-color": "#444",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                1.75
+              ],
+              [
+                18,
+                2.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                12
+              ],
+              [
+                18,
+                35
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "city_label_medium",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "place_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "city"
+          ],
+          [
+            "in",
+            "scalerank",
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                1
+              ],
+              [
+                20,
+                1.75
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "dot"
+              ],
+              [
+                5,
+                ""
+              ]
+            ]
+          },
+          "symbol-avoid-edges": true,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                4.99,
+                [
+                  0,
+                  0.3
+                ]
+              ],
+              [
+                5,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "text-rotation-alignment": "viewport",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "top"
+              ],
+              [
+                5,
+                "center"
+              ]
+            ]
+          },
+          "text-field": "{name}",
+          "text-letter-spacing": 0.05,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-color": "#555",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                1.25
+              ],
+              [
+                18,
+                2.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                9
+              ],
+              [
+                18,
+                23
+              ]
+            ]
+          },
+          "icon-size": 0.75,
+          "icon-opacity": 0.8
+        }
+      },
+      {
+        "id": "town_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "place_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "town"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                1
+              ],
+              [
+                20,
+                1.75
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 5,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.05,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-color": "#555",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                22
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hamlet_village_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "place_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "village",
+            "hamlet"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                1
+              ],
+              [
+                20,
+                1.75
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 10,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "🔨",
+          "text-letter-spacing": 0.05,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-color": "#555",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                8
+              ],
+              [
+                18,
+                20
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "neighborhood_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "place_label",
+        "minzoom": 0,
+        "maxzoom": 18,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "neighbourhood",
+            "suburb",
+            "Island"
+          ],
+          [
+            "<=",
+            "localrank",
+            3
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0.85
+              ],
+              [
+                20,
+                1.75
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Italic,    Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 15,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.15,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-color": "#633",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2.25
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                6
+              ],
+              [
+                18,
+                22
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "transport_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "airport",
+            "airfield"
+          ],
+          [
+            "<=",
+            "scalerank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                1.2
+              ],
+              [
+                20,
+                1.55
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 5,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.1,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "#333",
+          "text-halo-color": "#fff",
+          "text-halo-width": 1.25,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                6
+              ],
+              [
+                20,
+                24
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "networked_rail_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail"
+          ],
+          [
+            "in",
+            "network",
+            "rer",
+            "moscow-metro",
+            "london-overground",
+            "london-underground",
+            "dlr",
+            "national-rail",
+            "s-bahn",
+            "s-bahn.u-bahn",
+            "u-bahn",
+            "transilien",
+            "london-overground.london-underground",
+            "dlr.london-overground.london-underground.national-rail",
+            "dlr.london-underground",
+            "dlr.london-underground.national-rail",
+            "metro",
+            "london-overground.london-underground.national-rail",
+            "london-overground.national-rail",
+            "national-rail",
+            "wiener-linien",
+            "washington-metro",
+            "london-underground.national-rail",
+            "metro"
+          ]
+        ],
+        "layout": {
+          "text-optional": false,
+          "text-line-height": 1,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-offset": [
+            0,
+            0
+          ],
+          "icon-image": "{network}",
+          "symbol-avoid-edges": true,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-transform": "none",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "icon-allow-overlap": false,
+          "symbol-placement": "point",
+          "text-justify": "center",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                ""
+              ],
+              [
+                14,
+                "{name}"
+              ]
+            ]
+          },
+          "text-letter-spacing": 0.05,
+          "icon-padding": 0,
+          "text-max-width": 5.2,
+          "icon-ignore-placement": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                true
+              ],
+              [
+                13,
+                false
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "#333",
+          "text-halo-color": "@background",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          },
+          "icon-halo-width": 4,
+          "icon-halo-color": "#fff",
+          "text-opacity": 1,
+          "text-translate": [
+            0,
+            0
+          ]
+        }
+      },
+      {
+        "id": "generic_metro_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "rail-light",
+            "rail-metro"
+          ],
+          [
+            "!in",
+            "network",
+            "rer",
+            "moscow-metro",
+            "london-overground",
+            "london-underground",
+            "dlr",
+            "national-rail",
+            "s-bahn",
+            "s-bahn.u-bahn",
+            "u-bahn",
+            "transilien",
+            "london-overground.london-underground",
+            "dlr.london-overground.london-underground.national-rail",
+            "dlr.london-underground",
+            "dlr.london-underground.national-rail",
+            "metro",
+            "london-overground.london-underground.national-rail",
+            "london-overground.national-rail",
+            "national-rail",
+            "wiener-linien",
+            "washington-metro",
+            "london-underground.national-rail",
+            "metro"
+          ]
+        ],
+        "layout": {
+          "text-optional": false,
+          "text-line-height": 1,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-offset": [
+            0,
+            0
+          ],
+          "icon-image": "generic-metro",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-transform": "none",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "icon-allow-overlap": false,
+          "symbol-placement": "point",
+          "text-justify": "center",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                ""
+              ],
+              [
+                14,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-letter-spacing": 0.05,
+          "icon-padding": 0,
+          "text-max-width": 5.2,
+          "icon-ignore-placement": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                true
+              ],
+              [
+                13,
+                false
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "#464445",
+          "text-halo-color": "@background",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          },
+          "icon-halo-width": 4,
+          "icon-halo-color": "#fff",
+          "text-opacity": 1,
+          "text-translate": [
+            0,
+            0
+          ]
+        }
+      },
+      {
+        "id": "generic_rail_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "rail"
+          ],
+          [
+            "!in",
+            "network",
+            "rer",
+            "moscow-metro",
+            "london-overground",
+            "london-underground",
+            "dlr",
+            "national-rail",
+            "s-bahn",
+            "s-bahn.u-bahn",
+            "u-bahn",
+            "transilien",
+            "london-overground.london-underground",
+            "dlr.london-overground.london-underground.national-rail",
+            "dlr.london-underground",
+            "dlr.london-underground.national-rail",
+            "metro",
+            "london-overground.london-underground.national-rail",
+            "london-overground.national-rail",
+            "national-rail",
+            "wiener-linien",
+            "washington-metro",
+            "london-underground.national-rail",
+            "metro"
+          ]
+        ],
+        "layout": {
+          "text-optional": false,
+          "text-line-height": 1,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-offset": [
+            0,
+            0
+          ],
+          "icon-image": "generic-rail",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-transform": "none",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "icon-allow-overlap": false,
+          "symbol-placement": "point",
+          "text-justify": "center",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                ""
+              ],
+              [
+                14,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-letter-spacing": 0.05,
+          "icon-padding": 0,
+          "text-max-width": 5.2,
+          "icon-ignore-placement": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                true
+              ],
+              [
+                13,
+                false
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "#464445",
+          "text-halo-color": "@background",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          },
+          "icon-halo-width": 4,
+          "icon-halo-color": "#fff",
+          "text-opacity": 1,
+          "text-translate": [
+            0,
+            0
+          ]
+        }
+      },
+      {
+        "id": "road-label-large",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "main",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold,   Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-rotation-alignment": "map",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.05
+        },
+        "paint": {
+          "text-color": "#555",
+          "text-halo-color": "#fff",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                17
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-label-medium",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name}",
+          "symbol-placement": "line",
+          "text-rotation-alignment": "map",
+          "text-font": "Open Sans Regular,  Arial Unicode MS Regular",
+          "text-letter-spacing": 0.05,
+          "text-max-angle": 38,
+          "text-padding": 0
+        },
+        "paint": {
+          "text-color": "#666",
+          "text-halo-color": "#fff",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-label-small",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path",
+            "service",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name}",
+          "symbol-placement": "line",
+          "text-rotation-alignment": "map",
+          "text-font": "Open Sans Regular,  Arial Unicode MS Regular",
+          "text-letter-spacing": 0.1,
+          "text-ignore-placement": false,
+          "text-padding": 0
+        },
+        "paint": {
+          "text-color": "#555",
+          "text-halo-color": "#fff",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                15
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "us_interstate_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "shield",
+            "us-interstate",
+            "us-interstate-alternate",
+            "us-interstate-business",
+            "us-interstate-duplex"
+          ],
+          [
+            "<=",
+            "reflen",
+            3
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.4,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 2000,
+          "icon-offset": [
+            0,
+            -2.25
+          ],
+          "icon-image": "interstate_{reflen}",
+          "icon-rotation-alignment": "viewport",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "icon-keep-upright": true,
+          "text-font": "Open Sans Semibold,   Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "text-padding": 10,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "center",
+          "text-field": "{ref}",
+          "text-letter-spacing": 0.05,
+          "icon-padding": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                8
+              ],
+              [
+                20,
+                15
+              ]
+            ]
+          },
+          "text-color": "#fff",
+          "icon-halo-color": "white",
+          "icon-halo-width": 4,
+          "text-opacity": 1,
+          "text-halo-color": "#fff",
+          "icon-size": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                0.3
+              ],
+              [
+                20,
+                0.9
+              ]
+            ]
+          },
+          "text-halo-width": 0
+        }
+      },
+      {
+        "id": "us_highway_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "shield",
+            "us-highway",
+            "us-highway-alternate",
+            "us-highway-business",
+            "us-highway-duplex"
+          ],
+          [
+            "<=",
+            "reflen",
+            3
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "us_highway_{reflen}",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold,   Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 10,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{ref}",
+          "text-letter-spacing": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                17
+              ]
+            ]
+          },
+          "text-color": "#666",
+          "icon-halo-color": "rgba(0, 0, 0, 1)",
+          "icon-halo-width": 1,
+          "text-opacity": 1,
+          "icon-color": "white",
+          "text-halo-color": "#fff",
+          "icon-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0.6
+              ],
+              [
+                20,
+                1
+              ]
+            ]
+          },
+          "text-halo-width": 0
+        }
+      },
+      {
+        "id": "us_stateroad_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "shield",
+            "us-state",
+            "us-state-loop",
+            "us-state-business",
+            "us-state-toll",
+            "us-state-truck"
+          ],
+          [
+            "==",
+            "class",
+            "motorway"
+          ],
+          [
+            "<=",
+            "reflen",
+            3
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "us_state_{reflen}",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold,   Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 10,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{ref}",
+          "text-letter-spacing": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                15
+              ]
+            ]
+          },
+          "text-color": "#666",
+          "icon-halo-color": "rgba(0, 0, 0, 1)",
+          "icon-halo-width": 1,
+          "text-opacity": 1,
+          "icon-color": "white",
+          "text-halo-color": "#fff",
+          "icon-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0.7
+              ],
+              [
+                20,
+                1
+              ]
+            ]
+          },
+          "text-halo-width": 0
+        }
+      },
+      {
+        "id": "oneway_arrows_large",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "oneway",
+            1
+          ],
+          [
+            "in",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "text-line-height": 0,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "oneway_road",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold,   Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            0
+          ],
+          "text-rotation-alignment": "map",
+          "text-keep-upright": false,
+          "text-field": "",
+          "text-letter-spacing": 0.5
+        },
+        "paint": {
+          "text-color": "#aaa",
+          "text-halo-color": "#aaa",
+          "text-halo-width": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          },
+          "text-translate": [
+            0,
+            0
+          ]
+        }
+      },
+      {
+        "id": "oneway_arrows_small",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 18,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "oneway",
+            1
+          ],
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "oneway_road",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold,   Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-rotation-alignment": "map",
+          "text-keep-upright": false,
+          "text-field": "",
+          "text-letter-spacing": 0
+        },
+        "paint": {
+          "text-color": "#aaa",
+          "text-halo-color": "#aaa",
+          "text-halo-width": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          },
+          "text-translate": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                [
+                  0,
+                  -1
+                ]
+              ],
+              [
+                20,
+                [
+                  0,
+                  1
+                ]
+              ]
+            ]
+          },
+          "icon-size": 0.75
+        }
+      },
+      {
+        "id": "oneway_arrows_motorway",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road",
+        "minzoom": 16,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "oneway",
+            1
+          ],
+          [
+            "in",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "text-line-height": 0,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "oneway_motorway",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold,   Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-rotation-alignment": "map",
+          "text-anchor": "top",
+          "text-keep-upright": false,
+          "text-field": "",
+          "text-letter-spacing": 0
+        },
+        "paint": {
+          "text-color": "@generic_poi",
+          "text-halo-color": "#aaa",
+          "text-halo-width": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                18
+              ]
+            ]
+          },
+          "text-translate": [
+            0,
+            -2
+          ]
+        }
+      },
+      {
+        "id": "generic_motorway_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway",
+            "motorway_link"
+          ],
+          [
+            "==",
+            "shield",
+            "default"
+          ],
+          [
+            "<=",
+            "reflen",
+            6
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "default_{reflen}",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-transform": "uppercase",
+          "text-font": "Open Sans Semibold,   Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 10,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{ref}",
+          "text-letter-spacing": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          },
+          "text-color": "#666",
+          "icon-halo-color": "rgba(0, 0, 0, 1)",
+          "icon-halo-width": 1,
+          "text-opacity": 1,
+          "icon-color": "white",
+          "text-halo-color": "#fff",
+          "icon-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                1
+              ],
+              [
+                20,
+                1.25
+              ]
+            ]
+          },
+          "text-halo-width": 0
+        }
+      },
+      {
+        "id": "park_big_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "park",
+            "golf",
+            "zoo",
+            "Garden",
+            "cemetery"
+          ],
+          [
+            "==",
+            "scalerank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                1.2
+              ],
+              [
+                20,
+                1.8
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-transform": "uppercase",
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.2,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "#608275",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                12
+              ],
+              [
+                20,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "generic_big_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail",
+            "school",
+            "park",
+            "cemetery",
+            "college",
+            "golf",
+            "hospital"
+          ],
+          [
+            "<=",
+            "scalerank",
+            2
+          ],
+          [
+            "!in",
+            "type",
+            "Island",
+            "Wetland"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                1.2
+              ],
+              [
+                20,
+                1.8
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-transform": "uppercase",
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 5,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.2,
+          "text-max-width": 3.5
+        },
+        "paint": {
+          "text-color": "@generic_poi",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": 1.5,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                12
+              ],
+              [
+                20,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "park_small_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "in",
+            "maki",
+            "park",
+            "golf",
+            "zoo",
+            "cemetery"
+          ],
+          [
+            "==",
+            "type",
+            "Garden"
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.3,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.05,
+          "text-max-width": 8
+        },
+        "paint": {
+          "text-color": "#608275",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": 1.5,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "college_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "college"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                1
+              ],
+              [
+                20,
+                1.3
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 5,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.1,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "#895fb1",
+          "text-halo-color": "#fff",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                1
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                14
+              ]
+            ]
+          },
+          "text-halo-blur": 0.75
+        }
+      },
+      {
+        "id": "school_museum_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "in",
+            "maki",
+            "school",
+            "museum",
+            "library"
+          ],
+          [
+            "==",
+            "type",
+            "school"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0.95
+              ],
+              [
+                20,
+                1.2
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "symbol-avoid-edges": false,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 10,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.05,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "#6f59b1",
+          "text-halo-color": "@background",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                1.25
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hospital_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "hospital"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0.95
+              ],
+              [
+                20,
+                1.2
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 5,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.1,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "#c24246",
+          "text-halo-color": "#fff",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "religious_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "religious-christian",
+            "religious-jewish",
+            "religious-muslim"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0.95
+              ],
+              [
+                20,
+                1.2
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 5,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.05,
+          "text-max-width": 3.5
+        },
+        "paint": {
+          "text-color": "#46819b",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                1.25
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "government_label",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "in",
+            "maki",
+            "police",
+            "embassy",
+            "fire-station",
+            "post",
+            "prison",
+            "monument"
+          ],
+          [
+            "==",
+            "type",
+            "Military"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0.95
+              ],
+              [
+                20,
+                1.2
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 5,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.05,
+          "text-max-width": 3.5
+        },
+        "paint": {
+          "text-color": "#5c5a5b",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                2
+              ],
+              [
+                20,
+                3.75
+              ]
+            ]
+          },
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "generic_small_labels",
+        "type": "symbol",
+        "source": "compositedsource",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail",
+            "school",
+            "park",
+            "college",
+            "golf",
+            "station"
+          ],
+          [
+            ">=",
+            "scalerank",
+            3
+          ],
+          [
+            "!in",
+            "type",
+            "Apartments",
+            "Yes",
+            "Military"
+          ]
+        ],
+        "layout": {
+          "text-line-height": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0.95
+              ],
+              [
+                20,
+                1.2
+              ]
+            ]
+          },
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 16,
+          "text-font": "Open Sans Semibold Italic,     Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 5,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{name}",
+          "text-letter-spacing": 0.05,
+          "text-max-width": 3.5
+        },
+        "paint": {
+          "text-color": "@generic_poi",
+          "text-halo-color": "#F8F4F0",
+          "text-halo-width": 1.5,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          }
+        }
+      }
+    ],
+    "owner": "peterqliu",
+    "modified": "2015-04-09T22:26:37.136Z",
+    "created": "2015-04-09T21:22:48.511Z",
+    "id": "peterqliu.bf9a8d40"
+  },
   "empty": {
     "version": 7,
     "name": "Empty",
@@ -3026,6 +12647,10788 @@
     "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/sprite",
     "glyphs": "mapbox://fontstack/{fontstack}/{range}.pbf",
     "layers": []
+  },
+  "light": {
+    "version": 7,
+    "name": "light-v4-040915.json",
+    "constants": {
+      "@road-motorway-width": {
+        "base": 1,
+        "stops": [
+          [
+            3,
+            0.5
+          ],
+          [
+            9,
+            1.25
+          ],
+          [
+            20,
+            10
+          ]
+        ]
+      },
+      "@road-width-minor": {
+        "base": 1,
+        "stops": [
+          [
+            14,
+            0.5
+          ],
+          [
+            18,
+            12
+          ]
+        ]
+      },
+      "@sans_md": "Open Sans Semibold, Arial Unicode MS Bold",
+      "@admin-2-boundary": {
+        "base": 1,
+        "stops": [
+          [
+            3,
+            0.5
+          ],
+          [
+            10,
+            2
+          ]
+        ]
+      },
+      "@snow": "#fff",
+      "@label-park": "#4f4f4f",
+      "@road-major-width": {
+        "base": 1.4,
+        "stops": [
+          [
+            6,
+            0.5
+          ],
+          [
+            20,
+            30
+          ]
+        ]
+      },
+      "@color-1": {
+        "base": 1,
+        "stops": [
+          [
+            0,
+            "#393939"
+          ],
+          [
+            20,
+            "#393939"
+          ]
+        ]
+      },
+      "@road-minor": "#efefef",
+      "@road-street-width": {
+        "base": 1.55,
+        "stops": [
+          [
+            4,
+            0.25
+          ],
+          [
+            20,
+            20
+          ]
+        ]
+      },
+      "@rail-track-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            14,
+            4
+          ],
+          [
+            20,
+            8
+          ]
+        ]
+      },
+      "@building-outline": "#c0c0c0",
+      "@park": "#e4e4e4",
+      "@rail-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            14,
+            0.5
+          ],
+          [
+            20,
+            1
+          ]
+        ]
+      },
+      "@land": "#eee",
+      "@name": "{name_en}",
+      "@road-major": "#fff",
+      "@wood": "#dcdcdc",
+      "@number-2": {
+        "base": 1.5,
+        "stops": [
+          [
+            12.5,
+            0.3
+          ],
+          [
+            14,
+            2
+          ],
+          [
+            18,
+            18
+          ]
+        ]
+      },
+      "@sans_bd": "Open Sans Bold, Arial Unicode MS Bold",
+      "@scrub": "#e3e3e3",
+      "@crop": "#ececec",
+      "@label-waterway": "#929292",
+      "@main-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            6,
+            0.5
+          ],
+          [
+            18,
+            26
+          ]
+        ]
+      },
+      "@road-high-z-fadein": {
+        "base": 1,
+        "stops": [
+          [
+            5,
+            0
+          ],
+          [
+            5.5,
+            1
+          ]
+        ]
+      },
+      "@sans": "Open Sans Regular, Arial Unicode MS Regular",
+      "@motorway-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            5,
+            0.75
+          ],
+          [
+            18,
+            32
+          ]
+        ]
+      },
+      "@label": "#666",
+      "@label-halo": "#fff",
+      "@grass": "#e5e5e5",
+      "@water": "#d6d6d6",
+      "@state-label": {
+        "base": 1,
+        "stops": [
+          [
+            0,
+            "#929292"
+          ],
+          [
+            20,
+            "#929292"
+          ]
+        ]
+      },
+      "@label-road": "#929292",
+      "@label-secondary": "#5a5a5a",
+      "@building-fill": "#cbcbcb",
+      "@street-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            12.5,
+            0.5
+          ],
+          [
+            14,
+            2
+          ],
+          [
+            18,
+            18
+          ]
+        ]
+      },
+      "@path-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            15,
+            1
+          ],
+          [
+            18,
+            4
+          ]
+        ]
+      },
+      "@road-main-width": {
+        "base": 1.4,
+        "stops": [
+          [
+            6,
+            0.25
+          ],
+          [
+            20,
+            30
+          ]
+        ]
+      }
+    },
+    "sources": {
+      "mapbox": {
+        "url": "mapbox://mapbox.mapbox-streets-v6",
+        "type": "vector"
+      },
+      "mapbox://mapbox.mapbox-terrain-v2": {
+        "url": "mapbox://mapbox.mapbox-terrain-v2",
+        "type": "vector"
+      }
+    },
+    "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/light",
+    "glyphs": "mapbox://fontstack/{fontstack}/{range}.pbf",
+    "layers": [
+      {
+        "id": "background",
+        "type": "background",
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "background-color": "@land"
+        }
+      },
+      {
+        "id": "landcover_snow",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "snow"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@snow",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_crop",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "crop"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@crop",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_grass",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "grass"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@grass",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_scrub",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "scrub"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@scrub",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landcover_wood",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "wood"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@wood",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landuse_industrial",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "industrial"
+          ],
+          [
+            "==",
+            "$type",
+            "Polygon"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#fff",
+          "fill-opacity": 0.5
+        }
+      },
+      {
+        "id": "landuse_park",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "landuse",
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "park"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@park"
+        }
+      },
+      {
+        "id": "landuse_wood",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "landuse",
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "wood"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#e0e0e0"
+        }
+      },
+      {
+        "id": "hillshade_highlight_bright",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            94
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#fff",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0.15
+              ],
+              [
+                17,
+                0.05
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_highlight_med",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            90
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#fff",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0.15
+              ],
+              [
+                17,
+                0.05
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_shadow_faint",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            89
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#666",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                0.06
+              ],
+              [
+                17,
+                0.01
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_shadow_med",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            78
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#666",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                0.06
+              ],
+              [
+                17,
+                0.01
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_shadow_dark",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            67
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#888888",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                0.06
+              ],
+              [
+                17,
+                0.01
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hillshade_shadow_extreme",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            56
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#999",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                0.06
+              ],
+              [
+                17,
+                0.01
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "building",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "building",
+        "minzoom": 15,
+        "paint": {
+          "fill-outline-color": "@building-outline",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0
+              ],
+              [
+                16.5,
+                1
+              ]
+            ]
+          },
+          "fill-antialias": true,
+          "fill-color": "@building-fill"
+        }
+      },
+      {
+        "id": "waterway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "river",
+            "canal"
+          ]
+        ],
+        "paint": {
+          "line-color": "@water",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                0.25
+              ],
+              [
+                20,
+                6
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "waterway_stream",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "waterway",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "stream"
+          ]
+        ],
+        "paint": {
+          "line-color": "@water",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                0.75
+              ],
+              [
+                20,
+                4
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "water",
+        "type": "fill",
+        "source": "mapbox",
+        "source-layer": "water",
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@water"
+        }
+      },
+      {
+        "id": "aeroway_runway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "aeroway",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "type",
+            "runway"
+          ]
+        ],
+        "layout": {
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1.15,
+            "stops": [
+              [
+                11,
+                3
+              ],
+              [
+                20,
+                32
+              ]
+            ]
+          },
+          "line-color": "#fff",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                9,
+                0.5
+              ],
+              [
+                11,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "aeroway_taxiway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "aeroway",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "type",
+            "taxiway"
+          ]
+        ],
+        "layout": {
+          "line-join": "miter"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1.15,
+            "stops": [
+              [
+                10,
+                0.25
+              ],
+              [
+                11,
+                1
+              ],
+              [
+                20,
+                8
+              ]
+            ]
+          },
+          "line-color": "#fff"
+        }
+      },
+      {
+        "id": "tunnel_minor",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "tunnel",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "motorway_link",
+            "street",
+            "street_limited",
+            "service",
+            "driveway",
+            "path"
+          ]
+        ],
+        "paint": {
+          "line-color": "@road-minor",
+          "line-width": "@road-street-width",
+          "line-dasharray": [
+            0.36,
+            0.18
+          ]
+        }
+      },
+      {
+        "id": "tunnel_major",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "tunnel",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "motorway",
+            "main"
+          ]
+        ],
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@road-major-width",
+          "line-dasharray": [
+            0.28,
+            0.14
+          ]
+        }
+      },
+      {
+        "id": "road-path",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                1
+              ],
+              [
+                18,
+                4
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-street-low-zoom",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                11.5,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-service-driveway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service",
+            "driveway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@road-width-minor"
+        }
+      },
+      {
+        "id": "road-motorway_link",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width"
+        }
+      },
+      {
+        "id": "road-street_limited",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street_limited",
+            ""
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width"
+        }
+      },
+      {
+        "id": "road-street",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@number-2",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "road-main",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "main"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@main-width",
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "road-trunk",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "main"
+          ],
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@motorway-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "road-motorway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 0,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@motorway-width",
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "road-rail",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round",
+          "line-join": "round",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "road-rail-tracks",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "road",
+        "minzoom": 13,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "line-cap": "butt",
+          "line-join": "miter",
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-track-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge_minor_case",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "class",
+            "motorway_link",
+            "street",
+            "street_limited",
+            "service",
+            "driveway",
+            "path"
+          ]
+        ],
+        "paint": {
+          "line-color": "@land",
+          "line-width": {
+            "base": 1.6,
+            "stops": [
+              [
+                12,
+                0.5
+              ],
+              [
+                20,
+                10
+              ]
+            ]
+          },
+          "line-gap-width": "@road-street-width"
+        }
+      },
+      {
+        "id": "bridge-path",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-minor",
+          "line-width": "@path-width"
+        }
+      },
+      {
+        "id": "bridge-street-low-zoom",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 11,
+        "maxzoom": 14.1,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-minor",
+          "line-width": "@street-width",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                11.5,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge-motorway_link",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 10,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway_link"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-street_limited",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-street",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@street-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-main",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "main"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@main-width",
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "bridge-trunk",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "main"
+          ],
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@road-motorway-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-motorway",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@road-motorway-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-rail",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "miter",
+          "line-round-limit": 2
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-rail-tracks",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "miter",
+          "line-round-limit": 2
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-track-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-rail-tracks_copy",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "aerialway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "miter",
+          "line-round-limit": 2
+        },
+        "paint": {
+          "line-color": "@road-major",
+          "line-width": "@rail-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "admin-3-4-boundaries-bg",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "admin_level",
+            3
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "bevel"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                3.5
+              ],
+              [
+                12,
+                6
+              ]
+            ]
+          },
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                0
+              ],
+              [
+                5,
+                0.75
+              ]
+            ]
+          },
+          "line-color": "#fff"
+        }
+      },
+      {
+        "id": "admin-2-boundaries-bg",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "admin_level",
+            2
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ],
+          [
+            "==",
+            "disputed",
+            2
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "miter"
+        },
+        "paint": {
+          "line-color": "#fff",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                0
+              ],
+              [
+                4,
+                0.75
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                3.5
+              ],
+              [
+                10,
+                10
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "admin-3-4-boundaries",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "admin_level",
+            3
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "miter"
+        },
+        "paint": {
+          "line-color": "#b5b5b5",
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                0
+              ],
+              [
+                3,
+                1
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                0.5
+              ],
+              [
+                12,
+                2
+              ]
+            ]
+          },
+          "line-dasharray": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                [
+                  2,
+                  0
+                ]
+              ],
+              [
+                5,
+                [
+                  2,
+                  2,
+                  6,
+                  2
+                ]
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "admin-2-boundaries",
+        "type": "line",
+        "source": "mapbox",
+        "source-layer": "admin",
+        "minzoom": 1,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "admin_level",
+            2
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ],
+          [
+            "==",
+            "disputed",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "round",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "#c0c0c0",
+          "line-opacity": 1,
+          "line-width": "@admin-2-boundary"
+        }
+      },
+      {
+        "id": "country-label-lg",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "country_label",
+        "maxzoom": 12,
+        "filter": [
+          "all",
+          [
+            "in",
+            "scalerank",
+            1,
+            2
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "text-max-size": 18,
+          "text-max-width": 6
+        },
+        "paint": {
+          "text-color": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "#444"
+              ],
+              [
+                10,
+                "#888"
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                1,
+                9
+              ],
+              [
+                5,
+                18
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "country-label-md",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "country_label",
+        "minzoom": 1,
+        "maxzoom": 8,
+        "filter": [
+          "all",
+          [
+            "in",
+            "scalerank",
+            3,
+            4
+          ]
+        ],
+        "layout": {
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "{code}"
+              ],
+              [
+                2,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "text-max-size": 18,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "#444"
+              ],
+              [
+                10,
+                "#888"
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                2,
+                8
+              ],
+              [
+                7,
+                18
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "country-label-sm",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "country_label",
+        "minzoom": 1,
+        "maxzoom": 10,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "scalerank",
+            5
+          ]
+        ],
+        "layout": {
+          "text-field": "{name_en}",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular",
+          "text-max-size": 18,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "#444"
+              ],
+              [
+                10,
+                "#888"
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                3,
+                8
+              ],
+              [
+                9,
+                18
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "state-label-lg",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "state_label",
+        "minzoom": 3,
+        "maxzoom": 7,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "area",
+            80000
+          ]
+        ],
+        "layout": {
+          "text-transform": "uppercase",
+          "visibility": "visible",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "{abbr}"
+              ],
+              [
+                4,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "text-max-size": 10,
+          "text-letter-spacing": 0.15,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@state-label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                9
+              ],
+              [
+                7,
+                18
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "marine_label_line_1",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "labelrank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-max-width": 15,
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "@name",
+          "text-max-size": 30,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0.4,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                25
+              ],
+              [
+                4,
+                30
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_line_2",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "labelrank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-max-width": 15,
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "@name",
+          "text-max-size": 24,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                14
+              ],
+              [
+                5,
+                24
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_line_3",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "==",
+            "labelrank",
+            3
+          ]
+        ],
+        "layout": {
+          "text-max-width": 15,
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "@name",
+          "text-max-size": 18,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                13
+              ],
+              [
+                5,
+                18
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_line_other",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "LineString"
+          ],
+          [
+            "in",
+            "labelrank",
+            4,
+            5,
+            6
+          ]
+        ],
+        "layout": {
+          "text-max-width": 15,
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "@name",
+          "text-max-size": 16,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                12
+              ],
+              [
+                6,
+                16
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_point_1",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "==",
+            "labelrank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-max-width": 4,
+          "visibility": "visible",
+          "symbol-placement": "point",
+          "text-field": "@name",
+          "text-max-size": 30,
+          "text-line-height": 1.5,
+          "text-letter-spacing": 0.25,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                1,
+                12
+              ],
+              [
+                4,
+                30
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_point_2",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "==",
+            "labelrank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "visible",
+          "symbol-placement": "point",
+          "text-field": "@name",
+          "text-max-size": 24,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                14
+              ],
+              [
+                5,
+                24
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_point_3",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "==",
+            "labelrank",
+            3
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "visible",
+          "symbol-placement": "point",
+          "text-field": "@name",
+          "text-max-size": 18,
+          "text-line-height": 1.3,
+          "text-letter-spacing": 0.1,
+          "text-font": "Open Sans Semibold Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                13
+              ],
+              [
+                5,
+                18
+              ]
+            ]
+          },
+          "text-opacity": 0.25
+        }
+      },
+      {
+        "id": "marine_label_point_other",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "marine_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "in",
+            "labelrank",
+            4,
+            5,
+            6
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "none",
+          "symbol-placement": "point",
+          "text-field": "@name",
+          "text-max-size": 16,
+          "text-line-height": 1.2,
+          "text-letter-spacing": 0.1
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                12
+              ],
+              [
+                6,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place_label_city_large_n",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "<=",
+            "scalerank",
+            1
+          ],
+          [
+            "in",
+            "ldir",
+            "N",
+            "NE",
+            "NW",
+            "W"
+          ],
+          [
+            "==",
+            "type",
+            "city"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "@sans_bd",
+          "text-max-width": 5,
+          "text-max-size": 20,
+          "text-transform": "none",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "bottom"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  -0.2
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "symbol-avoid-edges": false
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                4,
+                11
+              ],
+              [
+                10,
+                20
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "place_label_city_large_s",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "<=",
+            "scalerank",
+            1
+          ],
+          [
+            "in",
+            "ldir",
+            "S",
+            "SE",
+            "SW",
+            "E"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "@sans_bd",
+          "text-max-width": 15,
+          "text-max-size": 20,
+          "text-transform": "none",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "top"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  0.1
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                4,
+                11
+              ],
+              [
+                10,
+                20
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "place_label_city_medium_n",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "<=",
+            "scalerank",
+            4
+          ],
+          [
+            ">",
+            "scalerank",
+            1
+          ],
+          [
+            "in",
+            "ldir",
+            "N",
+            "W",
+            "NW",
+            "NE"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-max-width": 10,
+          "text-max-size": 19,
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "bottom"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  -0.2
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                5,
+                11
+              ],
+              [
+                12,
+                19
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "place_label_city_medium_s",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "<=",
+            "scalerank",
+            4
+          ],
+          [
+            ">",
+            "scalerank",
+            1
+          ],
+          [
+            "in",
+            "ldir",
+            "S",
+            "E",
+            "SE",
+            "SW"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-max-width": 10,
+          "text-max-size": 19,
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "top"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  0.1
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                5,
+                11
+              ],
+              [
+                12,
+                19
+              ]
+            ],
+            "base": 0.9
+          }
+        }
+      },
+      {
+        "id": "place_label_city_small_n",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            ">",
+            "scalerank",
+            4
+          ],
+          [
+            "in",
+            "ldir",
+            "N",
+            "W",
+            "NW",
+            "NE"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-max-width": 10,
+          "text-max-size": 19,
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "bottom"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  -0.2
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                6,
+                11
+              ],
+              [
+                14,
+                19
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place_label_city_small_s",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            ">",
+            "scalerank",
+            4
+          ],
+          [
+            "in",
+            "ldir",
+            "S",
+            "E",
+            "SE",
+            "SW"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-max-width": 10,
+          "text-max-size": 19,
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "top"
+              ],
+              [
+                6,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                [
+                  0,
+                  0.1
+                ]
+              ],
+              [
+                6,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0,
+          "text-size": {
+            "stops": [
+              [
+                6,
+                11
+              ],
+              [
+                14,
+                19
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place_label_other",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "minzoom": 8,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "in",
+            "type",
+            "town",
+            "village",
+            "hamlet"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Regular, Arial Unicode MS Bold",
+          "text-max-width": 15,
+          "text-max-size": 18
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                6,
+                10
+              ],
+              [
+                12,
+                13
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place_label_neighborhood",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "place_label",
+        "minzoom": 12,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Point"
+          ],
+          [
+            "in",
+            "type",
+            "suburb",
+            "neighbourhood"
+          ]
+        ],
+        "layout": {
+          "text-field": "@name",
+          "text-font": "Open Sans Bold, Arial Unicode MS Bold",
+          "text-max-width": 7,
+          "text-max-size": 14,
+          "text-letter-spacing": 0.1,
+          "text-transform": "uppercase"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-size": {
+            "stops": [
+              [
+                12,
+                10
+              ],
+              [
+                16,
+                14
+              ]
+            ]
+          },
+          "text-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                0
+              ],
+              [
+                12,
+                0.66
+              ],
+              [
+                13,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "water-label",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "water_label",
+        "minzoom": 5,
+        "maxzoom": 22,
+        "layout": {
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular",
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@state-label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                12
+              ],
+              [
+                18,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-scalerank1",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail",
+            "airport",
+            "airfield",
+            "heliport",
+            "rocket",
+            "park",
+            "golf",
+            "cemetary",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "<=",
+            "scalerank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-size": 14,
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                "{maki}-11"
+              ],
+              [
+                14,
+                "{maki}-17"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label-secondary",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                14
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1
+        }
+      },
+      {
+        "id": "poi-parks-scalerank1",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "park",
+            "golf",
+            "cemetary",
+            "zoo",
+            "campsite",
+            "heliport",
+            "rocket",
+            "park",
+            "golf",
+            "cemetary",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "<=",
+            "scalerank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-max-width": 8,
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-size": 14,
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                "{maki}-11"
+              ],
+              [
+                14,
+                "{maki}-17"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-color": "@label-park",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                14
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1
+        }
+      },
+      {
+        "id": "airport-label",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "airport",
+            "heliport",
+            "rocket"
+          ],
+          [
+            "<=",
+            "scalerank",
+            2
+          ]
+        ],
+        "layout": {
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                12,
+                "{maki-11}"
+              ],
+              [
+                13,
+                "{maki-17}"
+              ]
+            ]
+          },
+          "visibility": "visible",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                12,
+                "{ref}"
+              ],
+              [
+                13,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-max-size": 18,
+          "text-max-width": 9,
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                18
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 0
+        }
+      },
+      {
+        "id": "road-label-large",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "road_label",
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway",
+            "main"
+          ]
+        ],
+        "layout": {
+          "symbol-placement": "line",
+          "text-field": "{name_en}",
+          "text-font": "Open Sans Semibold, Arial Unicode MS Bold",
+          "text-transform": "none",
+          "text-letter-spacing": 0,
+          "text-max-size": 16,
+          "text-padding": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                17
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 2,
+          "text-color": "@label-road"
+        }
+      },
+      {
+        "id": "road-label-med",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "road_label",
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ]
+        ],
+        "layout": {
+          "symbol-placement": "line",
+          "text-field": "{name_en}",
+          "text-font": "@sans_md",
+          "text-transform": "none",
+          "text-letter-spacing": 0,
+          "text-max-size": 16,
+          "text-padding": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                16
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 2,
+          "text-color": "@label-road"
+        }
+      },
+      {
+        "id": "road-label-sm",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "road_label",
+        "minzoom": 12,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "class",
+            "motorway",
+            "main",
+            "street_limited",
+            "street"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "symbol-placement": "line",
+          "text-field": "{name_en}",
+          "text-font": "@sans_md",
+          "text-transform": "none",
+          "text-letter-spacing": 0,
+          "text-max-size": 16,
+          "text-padding": 0
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                8
+              ],
+              [
+                20,
+                15
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "text-halo-width": 2,
+          "text-color": "@label-road"
+        }
+      },
+      {
+        "id": "waterway-label",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "waterway_label",
+        "minzoom": 12,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "river"
+          ]
+        ],
+        "layout": {
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular",
+          "visibility": "visible",
+          "symbol-placement": "line",
+          "text-field": "{name_en}"
+        },
+        "paint": {
+          "text-color": "@label-waterway",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                12
+              ],
+              [
+                18,
+                16
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "interstate-motorway_shields",
+        "type": "symbol",
+        "source": "mapbox",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "shield",
+            "us-interstate",
+            "us-interstate-business",
+            "us-interstate-duplex"
+          ],
+          [
+            "<=",
+            "reflen",
+            6
+          ]
+        ],
+        "layout": {
+          "symbol-min-distance": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                200
+              ],
+              [
+                15,
+                600
+              ]
+            ]
+          },
+          "icon-image": "default-4-small",
+          "text-max-angle": 38,
+          "text-max-size": 11,
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "visibility": "none",
+          "text-field": "{ref}",
+          "text-letter-spacing": 0.05
+        },
+        "paint": {
+          "text-color": "@label-road",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                15.95,
+                9
+              ],
+              [
+                16,
+                11
+              ]
+            ]
+          },
+          "text-halo-color": "@label-halo",
+          "icon-color": "white",
+          "icon-halo-width": 1,
+          "icon-halo-color": "rgba(0, 0, 0, 1)"
+        }
+      }
+    ],
+    "owner": "andreasviglakis",
+    "modified": "2015-04-10T21:22:55.274Z",
+    "created": "2015-04-10T00:53:04.196Z",
+    "id": "andreasviglakis.e1a9590a"
+  },
+  "mapbox-streets": {
+    "version": 7,
+    "name": "mapbox-streets-0409.json",
+    "constants": {
+      "@label-neighbourhood": "#755434",
+      "@hillshade-shadow": "#8f9100",
+      "@road-width-minor": {
+        "base": 1.5,
+        "stops": [
+          [
+            14,
+            0.5
+          ],
+          [
+            18,
+            12
+          ]
+        ]
+      },
+      "@wetlands": "#A7CECB",
+      "@landuse-cemetery": "#cad89e",
+      "@admin-2-boundary": {
+        "base": 1,
+        "stops": [
+          [
+            3,
+            0.5
+          ],
+          [
+            10,
+            2
+          ]
+        ]
+      },
+      "@snow": "#fff",
+      "@path-opacity": {
+        "base": 1,
+        "stops": [
+          [
+            15,
+            0
+          ],
+          [
+            15.25,
+            1
+          ]
+        ]
+      },
+      "@label-park": "#1e4c00",
+      "@landuse-school": "#eee7b9",
+      "@label-water-dark": "#004087",
+      "@road-main": "#a2a2a2",
+      "@road-case-dark": "#d1cac2",
+      "@path-bg-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            15,
+            2
+          ],
+          [
+            18,
+            7
+          ]
+        ]
+      },
+      "@road-trunk": "#f2d26c",
+      "@road-motorway": "#ff9340",
+      "@road-minor": "#fff",
+      "@rail-track-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            14,
+            4
+          ],
+          [
+            20,
+            8
+          ]
+        ]
+      },
+      "@label-primary": "#000000",
+      "@label-city-lg-size": {
+        "base": 0.9,
+        "stops": [
+          [
+            4,
+            11
+          ],
+          [
+            10,
+            20
+          ]
+        ]
+      },
+      "@landuse-industrial": "#e7d8e7",
+      "@landcover-opacity": {
+        "base": 1,
+        "stops": [
+          [
+            2,
+            0.25
+          ],
+          [
+            14,
+            0
+          ]
+        ]
+      },
+      "@rail-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            14,
+            0.5
+          ],
+          [
+            20,
+            1
+          ]
+        ]
+      },
+      "@landuse-hospital": "#f0d2d2",
+      "@land": "#e8e0d8",
+      "@name": "{name_en}",
+      "@landcover": "#cfe18f",
+      "@tunnel-case-dark": "#c4beb7",
+      "@aeroway": "#dacada",
+      "@label-city-md-size": {
+        "base": 0.9,
+        "stops": [
+          [
+            5,
+            11
+          ],
+          [
+            12,
+            20
+          ]
+        ]
+      },
+      "@landuse-pitch": "#d7e9b9",
+      "@admin": "#7f75a6",
+      "@road-case-width-sm": {
+        "base": 1.5,
+        "stops": [
+          [
+            12,
+            0.75
+          ],
+          [
+            20,
+            2
+          ]
+        ]
+      },
+      "@label-poi": "#65513d",
+      "@main-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            8.5,
+            0.5
+          ],
+          [
+            9.5,
+            1
+          ],
+          [
+            18,
+            26
+          ]
+        ]
+      },
+      "@road-case-width-lg": {
+        "base": 1.5,
+        "stops": [
+          [
+            5,
+            0.75
+          ],
+          [
+            16,
+            2
+          ]
+        ]
+      },
+      "@road-high-z-fadein": {
+        "base": 1.2,
+        "stops": [
+          [
+            5,
+            0
+          ],
+          [
+            5.5,
+            1
+          ]
+        ]
+      },
+      "@rail": "#99948e",
+      "@country-halo": "rgba(255,255,255,0.75)",
+      "@hillshade-highlight": "#ffffed",
+      "@motorway-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            5,
+            0.75
+          ],
+          [
+            18,
+            32
+          ]
+        ]
+      },
+      "@country-label-color": {
+        "stops": [
+          [
+            8,
+            "#000000"
+          ],
+          [
+            10,
+            "#888888"
+          ]
+        ],
+        "base": 1
+      },
+      "@building": "#dfd8d0",
+      "@landuse-sand": "#f0dfaf",
+      "@road-trunk-case": "#fff",
+      "@ramp-1": {
+        "base": 1,
+        "stops": [
+          [
+            0,
+            [
+              1,
+              2
+            ]
+          ],
+          [
+            20,
+            [
+              1,
+              0.25
+            ]
+          ]
+        ]
+      },
+      "@road-motorway-case": "#fff",
+      "@street_limited-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            12.5,
+            0.5
+          ],
+          [
+            14,
+            2
+          ],
+          [
+            18,
+            12
+          ]
+        ]
+      },
+      "@water": "#95c4e5",
+      "@label-state": "#242424",
+      "@landuse-parks": "#c7e09d",
+      "@street_limited-case-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            13,
+            0
+          ],
+          [
+            14,
+            2
+          ],
+          [
+            18,
+            12
+          ]
+        ]
+      },
+      "@motorway_link-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            12,
+            0.5
+          ],
+          [
+            14,
+            2
+          ],
+          [
+            18,
+            18
+          ]
+        ]
+      },
+      "@building-shadow": "#c8c1b9",
+      "@label-road": "#3a3836",
+      "@label-transit": "#000000",
+      "@street-case-gap-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            13,
+            0
+          ],
+          [
+            14,
+            2
+          ],
+          [
+            18,
+            18
+          ]
+        ]
+      },
+      "@halo": "#ffffff",
+      "@street-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            12.5,
+            0.5
+          ],
+          [
+            14,
+            2
+          ],
+          [
+            18,
+            18
+          ]
+        ]
+      },
+      "@main-case-width": {
+        "base": 1.2,
+        "stops": [
+          [
+            10,
+            0.75
+          ],
+          [
+            18,
+            2
+          ]
+        ]
+      },
+      "@road-street-limited": "#EFEDEB",
+      "@landuse-glacier": "#dcedf9",
+      "@label-water": "#c8e5f9",
+      "@path-width": {
+        "base": 1.5,
+        "stops": [
+          [
+            15,
+            1
+          ],
+          [
+            18,
+            4
+          ]
+        ]
+      },
+      "@tunnel-motorway": "#ffb57d"
+    },
+    "sources": {
+      "mapbox://mapbox.mapbox-streets-v6": {
+        "url": "mapbox://mapbox.mapbox-streets-v6",
+        "type": "vector"
+      },
+      "mapbox://mapbox.mapbox-terrain-v2": {
+        "url": "mapbox://mapbox.mapbox-terrain-v2",
+        "type": "vector"
+      }
+    },
+    "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/mapbox-streets",
+    "glyphs": "mapbox://fontstack/{fontstack}/{range}.pbf",
+    "layers": [
+      {
+        "id": "background",
+        "type": "background",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "background-color": "@land"
+        }
+      },
+      {
+        "id": "landcover_crop",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "crop"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landcover",
+          "fill-opacity": "@landcover-opacity",
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "landcover_grass",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "grass"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landcover",
+          "fill-opacity": "@landcover-opacity",
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "landcover_scrub",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "scrub"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landcover",
+          "fill-opacity": "@landcover-opacity",
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "landcover_wood",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "wood"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landcover",
+          "fill-opacity": "@landcover-opacity",
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "landcover_snow",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "landcover",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "snow"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@snow",
+          "fill-opacity": 0.2,
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "parks",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "park"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-parks",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                5,
+                0
+              ],
+              [
+                6,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "scrub",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 9,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "scrub"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-parks",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                9,
+                0
+              ],
+              [
+                16,
+                0.2
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "grass",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 9,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "grass"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-parks",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                9,
+                0
+              ],
+              [
+                16,
+                0.4
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "wood",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 6,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "wood"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landcover",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                0
+              ],
+              [
+                16,
+                0.5
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "hospital",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "hospital"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-hospital"
+        }
+      },
+      {
+        "id": "glaciers",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 9,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "glacier"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-glacier",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                9,
+                0
+              ],
+              [
+                10,
+                0.25
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "pitch",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "pitch"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-pitch"
+        }
+      },
+      {
+        "id": "pitch-line",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "pitch"
+          ]
+        ],
+        "layout": {},
+        "paint": {
+          "line-color": "#e4edd5"
+        }
+      },
+      {
+        "id": "school",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "school"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-school"
+        }
+      },
+      {
+        "id": "cemetery",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "cemetery"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-cemetery"
+        }
+      },
+      {
+        "id": "industrial",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "industrial"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-industrial"
+        }
+      },
+      {
+        "id": "sand",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "sand"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@landuse-sand"
+        }
+      },
+      {
+        "id": "hillshade_highlight_bright",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            94
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@hillshade-highlight",
+          "fill-opacity": {
+            "stops": [
+              [
+                15,
+                0.05
+              ],
+              [
+                18,
+                0
+              ]
+            ]
+          },
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "hillshade_highlight_med",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            90
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@hillshade-highlight",
+          "fill-opacity": {
+            "stops": [
+              [
+                15,
+                0.05
+              ],
+              [
+                18,
+                0
+              ]
+            ]
+          },
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "hillshade_shadow_faint",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            89
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@hillshade-shadow",
+          "fill-opacity": {
+            "stops": [
+              [
+                15,
+                0.03
+              ],
+              [
+                17,
+                0
+              ]
+            ]
+          },
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "hillshade_shadow_med",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            78
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@hillshade-shadow",
+          "fill-opacity": {
+            "stops": [
+              [
+                15,
+                0.04
+              ],
+              [
+                17,
+                0
+              ]
+            ]
+          },
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "hillshade_shadow_dark",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            67
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@hillshade-shadow",
+          "fill-opacity": {
+            "stops": [
+              [
+                15,
+                0.05
+              ],
+              [
+                17,
+                0
+              ]
+            ]
+          },
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "hillshade_shadow_extreme",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "hillshade",
+        "filter": [
+          "all",
+          [
+            "==",
+            "level",
+            56
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@hillshade-shadow",
+          "fill-opacity": {
+            "stops": [
+              [
+                15,
+                0.05
+              ],
+              [
+                17,
+                0
+              ]
+            ]
+          },
+          "fill-antialias": false
+        }
+      },
+      {
+        "id": "waterway-river",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "waterway",
+        "minzoom": 8,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "==",
+            "class",
+            "river"
+          ],
+          [
+            "==",
+            "class",
+            "canal"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "butt"
+              ],
+              [
+                11,
+                "round"
+              ]
+            ]
+          },
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@water",
+          "line-width": {
+            "base": 1.3,
+            "stops": [
+              [
+                8.5,
+                0.1
+              ],
+              [
+                20,
+                8
+              ]
+            ]
+          },
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                0
+              ],
+              [
+                8.5,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "waterway-other",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "waterway",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!=",
+            "class",
+            "river"
+          ],
+          [
+            "!=",
+            "class",
+            "canal"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "round",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "@water",
+          "line-width": {
+            "base": 1.35,
+            "stops": [
+              [
+                13.5,
+                0.1
+              ],
+              [
+                20,
+                3
+              ]
+            ]
+          },
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                0
+              ],
+              [
+                13.5,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "water",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "water",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@water"
+        }
+      },
+      {
+        "id": "landuse-overlay",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "landuse_overlay",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all"
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@wetlands",
+          "fill-opacity": 0.25
+        }
+      },
+      {
+        "id": "barrier_line-land-polygon",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "barrier_line",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "land"
+          ],
+          [
+            "==",
+            "$type",
+            "Polygon"
+          ]
+        ],
+        "layout": {},
+        "paint": {
+          "fill-color": "@land"
+        }
+      },
+      {
+        "id": "barrier_line-land-line",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "barrier_line",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "land"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1.99,
+            "stops": [
+              [
+                14,
+                0.75
+              ],
+              [
+                20,
+                40
+              ]
+            ]
+          },
+          "line-color": "@land"
+        }
+      },
+      {
+        "id": "building-bottom",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "building",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "@building-shadow",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                0
+              ],
+              [
+                16.5,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "building-top",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "building",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                "@land"
+              ],
+              [
+                16,
+                "@building"
+              ]
+            ]
+          },
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0
+              ],
+              [
+                16.5,
+                1
+              ]
+            ]
+          },
+          "fill-outline-color": "#d1cac1",
+          "fill-translate": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                [
+                  0,
+                  0
+                ]
+              ],
+              [
+                20,
+                [
+                  -6,
+                  -6
+                ]
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "building-top-fill-style",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "building",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "none"
+        },
+        "paint": {
+          "fill-color": "@building",
+          "fill-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15.25,
+                0
+              ],
+              [
+                16,
+                1
+              ]
+            ]
+          },
+          "fill-outline-color": "@building-shadow",
+          "fill-translate": {
+            "base": 1,
+            "stops": [
+              [
+                15.5,
+                [
+                  0,
+                  0
+                ]
+              ],
+              [
+                18,
+                [
+                  -4,
+                  -4
+                ]
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "building-fill-style",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "building",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "none"
+        },
+        "paint": {
+          "fill-color": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                "@land"
+              ],
+              [
+                15.25,
+                "@building"
+              ],
+              [
+                16,
+                "@building-shadow"
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "aeroway-polygon",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "aeroway",
+        "minzoom": 9,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "$type",
+            "Polygon"
+          ],
+          [
+            "!=",
+            "type",
+            "apron"
+          ]
+        ],
+        "layout": {},
+        "paint": {
+          "fill-color": "@aeroway"
+        }
+      },
+      {
+        "id": "aeroway-runway",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "aeroway",
+        "minzoom": 9,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "runway"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@aeroway",
+          "line-width": {
+            "base": 1.5,
+            "stops": [
+              [
+                9,
+                1
+              ],
+              [
+                18,
+                80
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "aeroway-taxiway",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "aeroway",
+        "minzoom": 9,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "taxiway"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@aeroway",
+          "line-width": {
+            "base": 1.5,
+            "stops": [
+              [
+                10,
+                0.5
+              ],
+              [
+                18,
+                20
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "admin-3-4-boundaries-bg",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "admin_level",
+            3
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "bevel"
+        },
+        "paint": {
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                8,
+                "@land"
+              ],
+              [
+                16,
+                "#fadfd4"
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                3.5
+              ],
+              [
+                10,
+                8
+              ]
+            ]
+          },
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                0
+              ],
+              [
+                8,
+                0.75
+              ]
+            ]
+          },
+          "line-dasharray": [
+            1,
+            0
+          ],
+          "line-translate": [
+            0,
+            0
+          ]
+        }
+      },
+      {
+        "id": "tunnel-street_limited-polygon",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "Polygon"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#EEE8E3",
+          "fill-opacity": 0.75
+        }
+      },
+      {
+        "id": "tunnel-path-bg",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "none",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@path-bg-width",
+          "line-dasharray": [
+            1,
+            0
+          ],
+          "line-color": "@road-case-dark",
+          "line-blur": 0,
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0
+              ],
+              [
+                15.25,
+                0.5
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "tunnel-path",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@path-width",
+          "line-dasharray": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                [
+                  0.1,
+                  1.25
+                ]
+              ],
+              [
+                16,
+                [
+                  0.1,
+                  1.6
+                ]
+              ],
+              [
+                17,
+                [
+                  0.1,
+                  1.45
+                ]
+              ],
+              [
+                18,
+                [
+                  0.1,
+                  1.3
+                ]
+              ]
+            ]
+          },
+          "line-color": "#f5f2ee",
+          "line-opacity": "@path-opacity"
+        }
+      },
+      {
+        "id": "tunnel-street-low-zoom",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 11,
+        "maxzoom": 14.1,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@street-width",
+          "line-color": "@road-minor",
+          "line-opacity": {
+            "stops": [
+              [
+                11.5,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "tunnel-motorway_link-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 11,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@road-motorway-case",
+          "line-gap-width": "@motorway_link-width",
+          "line-dasharray": [
+            3,
+            3
+          ]
+        }
+      },
+      {
+        "id": "tunnel-service-driveway-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service",
+            "driveway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@tunnel-case-dark",
+          "line-gap-width": "@road-width-minor"
+        }
+      },
+      {
+        "id": "tunnel-street_limited-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@tunnel-case-dark",
+          "line-gap-width": "@street_limited-case-width",
+          "line-dasharray": [
+            3,
+            3
+          ]
+        }
+      },
+      {
+        "id": "tunnel-street-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@tunnel-case-dark",
+          "line-gap-width": "@street-case-gap-width",
+          "line-dasharray": [
+            3,
+            3
+          ]
+        }
+      },
+      {
+        "id": "tunnel-main-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 8,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@main-case-width",
+          "line-dasharray": [
+            3,
+            3
+          ],
+          "line-gap-width": "@main-width",
+          "line-color": "@tunnel-case-dark"
+        }
+      },
+      {
+        "id": "tunel-motorway-trunk-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 5,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "in",
+            "class",
+            "motorway"
+          ],
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-lg",
+          "line-color": "@road-motorway-case",
+          "line-gap-width": "@motorway-width",
+          "line-opacity": 1,
+          "line-dasharray": [
+            3,
+            3
+          ]
+        }
+      },
+      {
+        "id": "tunnel-motorway_link",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 11,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@motorway_link-width",
+          "line-color": "@tunnel-motorway",
+          "line-opacity": 1,
+          "line-dasharray": [
+            1,
+            0
+          ]
+        }
+      },
+      {
+        "id": "tunnel-service-driveway",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service",
+            "driveway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-width-minor",
+          "line-color": "@road-minor"
+        }
+      },
+      {
+        "id": "tunnel-street_limited",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@street_limited-width",
+          "line-color": "@road-street-limited",
+          "line-opacity": {
+            "stops": [
+              [
+                11.5,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "tunnel-street",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@street-width",
+          "line-color": "@road-minor",
+          "line-opacity": {
+            "stops": [
+              [
+                11.5,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "tunnel-main",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@main-width",
+          "line-color": "@road-minor",
+          "line-opacity": 1,
+          "line-dasharray": [
+            1,
+            0
+          ],
+          "line-blur": 0
+        }
+      },
+      {
+        "id": "tunnel-trunk",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@motorway-width",
+          "line-color": "#f2dc92"
+        }
+      },
+      {
+        "id": "tunnel-motorway",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@motorway-width",
+          "line-dasharray": [
+            1,
+            0
+          ],
+          "line-opacity": 1,
+          "line-color": "@tunnel-motorway",
+          "line-blur": 0
+        }
+      },
+      {
+        "id": "tunnel-oneway-arrows-white",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "oneway",
+            1
+          ],
+          [
+            "any",
+            [
+              "in",
+              "class",
+              "motorway",
+              "motorway_link"
+            ],
+            [
+              "in",
+              "type",
+              "trunk"
+            ]
+          ]
+        ],
+        "layout": {
+          "symbol-min-distance": 250,
+          "symbol-placement": "line",
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                "oneway-spaced-white-small"
+              ],
+              [
+                17,
+                "oneway-spaced-white-large"
+              ]
+            ]
+          },
+          "icon-ignore-placement": true
+        },
+        "paint": {}
+      },
+      {
+        "id": "tunnel-oneway-arrows-color",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "oneway",
+            1
+          ],
+          [
+            "in",
+            "class",
+            "main",
+            "street",
+            "street_limited"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "symbol-min-distance": 250,
+          "symbol-placement": "line",
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                "oneway-spaced-small"
+              ],
+              [
+                17,
+                "oneway-spaced-large"
+              ]
+            ]
+          },
+          "icon-ignore-placement": true
+        },
+        "paint": {}
+      },
+      {
+        "id": "tunnel-rail",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "#a49f98",
+          "line-width": "@rail-width"
+        }
+      },
+      {
+        "id": "tunnel-rail-tracks",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "tunnel",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@rail",
+          "line-width": "@rail-track-width",
+          "line-dasharray": [
+            0.1,
+            15
+          ]
+        }
+      },
+      {
+        "id": "road-path-bg",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@path-bg-width",
+          "line-dasharray": [
+            1,
+            0
+          ],
+          "line-color": "@road-case-dark",
+          "line-blur": 0,
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0
+              ],
+              [
+                15.25,
+                0.5
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-path",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@path-width",
+          "line-color": "@road-minor",
+          "line-dasharray": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                [
+                  0.1,
+                  1.25
+                ]
+              ],
+              [
+                16,
+                [
+                  0.1,
+                  1.6
+                ]
+              ],
+              [
+                17,
+                [
+                  0.1,
+                  1.45
+                ]
+              ],
+              [
+                18,
+                [
+                  0.1,
+                  1.3
+                ]
+              ]
+            ]
+          },
+          "line-opacity": "@path-opacity"
+        }
+      },
+      {
+        "id": "road-street_limited-polygon-outline",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 12,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "Polygon"
+          ]
+        ],
+        "layout": {
+          "visibility": "none"
+        },
+        "paint": {
+          "line-color": "@road-case-dark",
+          "line-width": {
+            "base": 1.5,
+            "stops": [
+              [
+                12,
+                1.5
+              ],
+              [
+                20,
+                4
+              ]
+            ]
+          },
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "road-street-low-zoom",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 11,
+        "maxzoom": 14.1,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@street-width",
+          "line-color": "@road-minor",
+          "line-opacity": {
+            "stops": [
+              [
+                11,
+                0
+              ],
+              [
+                11.25,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-motorway_link-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 11,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@road-motorway-case",
+          "line-gap-width": "@motorway_link-width"
+        }
+      },
+      {
+        "id": "road-service-driveway-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service",
+            "driveway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@road-case-dark",
+          "line-gap-width": "@road-width-minor"
+        }
+      },
+      {
+        "id": "road-street_limited-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@road-case-dark",
+          "line-gap-width": "@street_limited-case-width"
+        }
+      },
+      {
+        "id": "road-street-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@road-case-dark",
+          "line-gap-width": "@street-case-gap-width"
+        }
+      },
+      {
+        "id": "road-main-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 10,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@main-case-width",
+          "line-color": "@road-case-dark",
+          "line-gap-width": "@main-width"
+        }
+      },
+      {
+        "id": "road-trunk-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 5,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "main"
+          ],
+          [
+            "in",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-lg",
+          "line-color": "@road-trunk-case",
+          "line-gap-width": "@motorway-width",
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "road-motorway-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 5,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-lg",
+          "line-color": "@road-motorway-case",
+          "line-gap-width": "@motorway-width",
+          "line-opacity": {
+            "base": 1.2,
+            "stops": [
+              [
+                5.9,
+                0
+              ],
+              [
+                6,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-street_limited-polygon",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 12,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "Polygon"
+          ]
+        ],
+        "layout": {
+          "visibility": "none"
+        },
+        "paint": {
+          "fill-color": "@road-street-limited",
+          "fill-opacity": 1
+        }
+      },
+      {
+        "id": "road-service-driveway",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service",
+            "driveway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-width-minor",
+          "line-color": "@road-minor"
+        }
+      },
+      {
+        "id": "road-motorway_link",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 10,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@motorway_link-width",
+          "line-color": "@road-motorway",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "road-street_limited",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@street_limited-width",
+          "line-color": "@road-street-limited"
+        }
+      },
+      {
+        "id": "road-street",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@street-width",
+          "line-color": "@road-minor"
+        }
+      },
+      {
+        "id": "road-main",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@main-width",
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                5,
+                "@land"
+              ],
+              [
+                8,
+                "@road-minor"
+              ]
+            ]
+          },
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "road-trunk",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@motorway-width",
+          "line-color": "@road-trunk"
+        }
+      },
+      {
+        "id": "road-motorway",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@motorway-width",
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                5.9,
+                "#fff"
+              ],
+              [
+                6,
+                "#ff9340"
+              ]
+            ]
+          },
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "road-oneway-arrows-white",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "oneway",
+            1
+          ],
+          [
+            "any",
+            [
+              "in",
+              "class",
+              "motorway",
+              "motorway_link"
+            ],
+            [
+              "in",
+              "type",
+              "trunk"
+            ]
+          ]
+        ],
+        "layout": {
+          "symbol-min-distance": 250,
+          "symbol-placement": "line",
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                "oneway-spaced-white-small"
+              ],
+              [
+                17,
+                "oneway-spaced-white-large"
+              ]
+            ]
+          },
+          "icon-ignore-placement": true
+        },
+        "paint": {}
+      },
+      {
+        "id": "road-oneway-arrows-color",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "oneway",
+            1
+          ],
+          [
+            "in",
+            "class",
+            "main",
+            "street",
+            "street_limited"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "symbol-min-distance": 250,
+          "symbol-placement": "line",
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                "oneway-spaced-small"
+              ],
+              [
+                17,
+                "oneway-spaced-large"
+              ]
+            ]
+          },
+          "icon-ignore-placement": true,
+          "icon-rotation-alignment": "map"
+        },
+        "paint": {}
+      },
+      {
+        "id": "road-rail",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@rail",
+          "line-width": "@rail-width"
+        }
+      },
+      {
+        "id": "road-rail-tracks",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@rail",
+          "line-width": "@rail-track-width",
+          "line-dasharray": [
+            0.1,
+            15
+          ]
+        }
+      },
+      {
+        "id": "bridge-street_limited-polygon",
+        "type": "fill",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "Polygon"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "fill-color": "#EEE8E3",
+          "fill-opacity": 0.75
+        }
+      },
+      {
+        "id": "bridge-path-bg",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@path-bg-width",
+          "line-dasharray": [
+            1,
+            0
+          ],
+          "line-color": "@road-case-dark",
+          "line-blur": 0,
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                15,
+                0
+              ],
+              [
+                15.25,
+                0.75
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge-path",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "path"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@path-width",
+          "line-color": "@road-minor",
+          "line-dasharray": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                [
+                  0.1,
+                  1.25
+                ]
+              ],
+              [
+                16,
+                [
+                  0.1,
+                  1.6
+                ]
+              ],
+              [
+                17,
+                [
+                  0.1,
+                  1.45
+                ]
+              ],
+              [
+                18,
+                [
+                  0.1,
+                  1.3
+                ]
+              ]
+            ]
+          },
+          "line-opacity": "@path-opacity"
+        }
+      },
+      {
+        "id": "bridge-street-low-zoom",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 11,
+        "maxzoom": 14.1,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@street-width",
+          "line-color": "@road-minor",
+          "line-opacity": {
+            "stops": [
+              [
+                11.5,
+                0
+              ],
+              [
+                12,
+                1
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "bridge-motorway_link-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 12,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@road-motorway-case",
+          "line-gap-width": "@motorway_link-width",
+          "line-opacity": 1
+        }
+      },
+      {
+        "id": "bridge-service-driveway-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service",
+            "driveway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@road-case-dark",
+          "line-gap-width": "@road-width-minor"
+        }
+      },
+      {
+        "id": "bridge-street_limited-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@road-case-dark",
+          "line-gap-width": "@street_limited-case-width"
+        }
+      },
+      {
+        "id": "bridge-street-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-sm",
+          "line-color": "@road-case-dark",
+          "line-gap-width": "@street-case-gap-width"
+        }
+      },
+      {
+        "id": "bridge-main-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 8,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@main-case-width",
+          "line-color": "@road-case-dark",
+          "line-gap-width": "@main-width",
+          "line-translate": [
+            0,
+            0
+          ]
+        }
+      },
+      {
+        "id": "bridge-motorway-trunk-case",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "any",
+          [
+            "in",
+            "class",
+            "motorway"
+          ],
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-case-width-lg",
+          "line-color": "@road-motorway-case",
+          "line-gap-width": "@motorway-width"
+        }
+      },
+      {
+        "id": "bridge-motorway_link",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 10,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway_link"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@motorway_link-width",
+          "line-color": "@road-motorway"
+        }
+      },
+      {
+        "id": "bridge-service-driveway",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "service",
+            "driveway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@road-width-minor",
+          "line-color": "@road-minor"
+        }
+      },
+      {
+        "id": "bridge-street_limited",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@street_limited-width",
+          "line-color": "@road-street-limited"
+        }
+      },
+      {
+        "id": "bridge-street",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "street"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@street-width",
+          "line-color": "@road-minor"
+        }
+      },
+      {
+        "id": "bridge-main",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@main-width",
+          "line-color": "@road-minor",
+          "line-opacity": "@road-high-z-fadein"
+        }
+      },
+      {
+        "id": "bridge-trunk",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "main"
+          ],
+          [
+            "==",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@motorway-width",
+          "line-color": "@road-trunk"
+        }
+      },
+      {
+        "id": "bridge-motorway",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-width": "@motorway-width",
+          "line-color": "@road-motorway"
+        }
+      },
+      {
+        "id": "bridge-oneway-arrows-white",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "oneway",
+            1
+          ],
+          [
+            "any",
+            [
+              "in",
+              "class",
+              "motorway",
+              "motorway_link"
+            ],
+            [
+              "in",
+              "type",
+              "trunk"
+            ]
+          ]
+        ],
+        "layout": {
+          "symbol-min-distance": 250,
+          "symbol-placement": "line",
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                "oneway-spaced-white-small"
+              ],
+              [
+                17,
+                "oneway-spaced-white-large"
+              ]
+            ]
+          },
+          "icon-ignore-placement": true
+        },
+        "paint": {}
+      },
+      {
+        "id": "bridge-oneway-arrows-color",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "oneway",
+            1
+          ],
+          [
+            "in",
+            "class",
+            "main",
+            "street",
+            "street_limited"
+          ],
+          [
+            "!=",
+            "type",
+            "trunk"
+          ]
+        ],
+        "layout": {
+          "symbol-min-distance": 250,
+          "symbol-placement": "line",
+          "icon-image": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                "oneway-spaced-small"
+              ],
+              [
+                17,
+                "oneway-spaced-large"
+              ]
+            ]
+          },
+          "icon-ignore-placement": true
+        },
+        "paint": {}
+      },
+      {
+        "id": "bridge-rail",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@rail",
+          "line-width": "@rail-width"
+        }
+      },
+      {
+        "id": "bridge-rail-tracks",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 14,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "major_rail",
+            "minor_rail"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@rail",
+          "line-width": "@rail-track-width",
+          "line-dasharray": [
+            0.1,
+            15
+          ]
+        }
+      },
+      {
+        "id": "bridge-aerialway",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "bridge",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "aerialway"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-color": "@rail",
+          "line-width": "@rail-width"
+        }
+      },
+      {
+        "id": "hedges",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "barrier_line",
+        "minzoom": 16,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "hedge"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "#e2f4c2",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                1
+              ],
+              [
+                20,
+                3
+              ]
+            ]
+          },
+          "line-opacity": 1,
+          "line-dasharray": [
+            1,
+            2,
+            5,
+            2,
+            1,
+            2
+          ]
+        }
+      },
+      {
+        "id": "fences",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "barrier_line",
+        "minzoom": 16,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "fence"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@building-shadow",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                1
+              ],
+              [
+                20,
+                3
+              ]
+            ]
+          },
+          "line-opacity": 1,
+          "line-dasharray": [
+            1,
+            2,
+            5,
+            2,
+            1,
+            2
+          ]
+        }
+      },
+      {
+        "id": "gates",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "barrier_line",
+        "minzoom": 17,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "gate"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "round",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-color": "@building-shadow",
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                1
+              ],
+              [
+                20,
+                3
+              ]
+            ]
+          },
+          "line-opacity": 0.5,
+          "line-dasharray": [
+            1,
+            2,
+            5,
+            2,
+            1,
+            2
+          ]
+        }
+      },
+      {
+        "id": "admin-2-boundaries-bg",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "admin",
+        "minzoom": 1,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "admin_level",
+            2
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "miter",
+          "line-cap": "butt"
+        },
+        "paint": {
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                3.5
+              ],
+              [
+                10,
+                10
+              ]
+            ]
+          },
+          "line-color": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                "@land"
+              ],
+              [
+                6,
+                "#fadfd4"
+              ]
+            ]
+          },
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                0
+              ],
+              [
+                4,
+                0.5
+              ]
+            ]
+          },
+          "line-translate": [
+            0,
+            0
+          ]
+        }
+      },
+      {
+        "id": "admin-3-4-boundaries",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "admin",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "admin_level",
+            3
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "round",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-dasharray": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                [
+                  2,
+                  0
+                ]
+              ],
+              [
+                7,
+                [
+                  2,
+                  2,
+                  6,
+                  2
+                ]
+              ]
+            ]
+          },
+          "line-width": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                0.75
+              ],
+              [
+                12,
+                1.5
+              ]
+            ]
+          },
+          "line-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                0
+              ],
+              [
+                3,
+                1
+              ]
+            ]
+          },
+          "line-color": "#a7a1be"
+        }
+      },
+      {
+        "id": "admin-2-boundaries",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "admin",
+        "minzoom": 1,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "admin_level",
+            2
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ],
+          [
+            "==",
+            "disputed",
+            0
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-join": "round",
+          "line-cap": "round"
+        },
+        "paint": {
+          "line-color": "@admin",
+          "line-width": "@admin-2-boundary"
+        }
+      },
+      {
+        "id": "admin-2-boundaries-dispute",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "admin",
+        "minzoom": 1,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "admin_level",
+            2
+          ],
+          [
+            "==",
+            "maritime",
+            0
+          ],
+          [
+            "==",
+            "disputed",
+            1
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "line-cap": "butt",
+          "line-join": "round"
+        },
+        "paint": {
+          "line-dasharray": [
+            1.5,
+            1.5
+          ],
+          "line-color": "@admin",
+          "line-width": "@admin-2-boundary"
+        }
+      },
+      {
+        "id": "contour",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "contour",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!=",
+            "index",
+            5
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-opacity": 0.06,
+          "line-color": "#5b5c00"
+        }
+      },
+      {
+        "id": "contour-index",
+        "type": "line",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "contour",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "index",
+            5
+          ]
+        ],
+        "layout": {
+          "visibility": "visible"
+        },
+        "paint": {
+          "line-opacity": 0.12,
+          "line-color": "#5b5c00"
+        }
+      },
+      {
+        "id": "country-label-lg",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "country_label",
+        "minzoom": 1,
+        "maxzoom": 6,
+        "filter": [
+          "all",
+          [
+            "in",
+            "scalerank",
+            1,
+            2
+          ]
+        ],
+        "layout": {
+          "text-field": "{name_en}",
+          "visibility": "visible",
+          "text-max-size": 18,
+          "text-max-width": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                6
+              ],
+              [
+                3,
+                6.5
+              ]
+            ]
+          },
+          "text-font": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "Open Sans Regular, Arial Unicode MS Regular"
+              ],
+              [
+                3,
+                "Open Sans Semibold, Arial Unicode MS Bold"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                1,
+                9
+              ],
+              [
+                6,
+                22
+              ]
+            ]
+          },
+          "text-color": "@label-primary",
+          "text-halo-color": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                "@country-halo"
+              ],
+              [
+                3,
+                "@halo"
+              ]
+            ]
+          },
+          "text-halo-width": 1.25
+        }
+      },
+      {
+        "id": "country-label-md",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "country_label",
+        "minzoom": 1,
+        "maxzoom": 8,
+        "filter": [
+          "all",
+          [
+            "in",
+            "scalerank",
+            3,
+            4
+          ]
+        ],
+        "layout": {
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "{code}"
+              ],
+              [
+                2,
+                "{name_en}"
+              ]
+            ]
+          },
+          "visibility": "visible",
+          "text-max-size": 18,
+          "text-max-width": 7,
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                8
+              ],
+              [
+                8,
+                22
+              ]
+            ]
+          },
+          "text-color": "@label-primary",
+          "text-halo-color": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                "@country-halo"
+              ],
+              [
+                3,
+                "@halo"
+              ]
+            ]
+          },
+          "text-halo-width": 1.25
+        }
+      },
+      {
+        "id": "country-label-sm",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "country_label",
+        "minzoom": 1,
+        "maxzoom": 10,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "scalerank",
+            5
+          ]
+        ],
+        "layout": {
+          "text-field": "{name_en}",
+          "visibility": "visible",
+          "text-max-size": 18,
+          "text-max-width": 7,
+          "text-font": "Open Sans Semibold, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-size": {
+            "base": 0.9,
+            "stops": [
+              [
+                3,
+                8
+              ],
+              [
+                9,
+                20
+              ]
+            ]
+          },
+          "text-color": "@label-primary",
+          "text-halo-color": {
+            "base": 1,
+            "stops": [
+              [
+                2,
+                "@country-halo"
+              ],
+              [
+                3,
+                "@halo"
+              ]
+            ]
+          },
+          "text-halo-width": 1.25
+        }
+      },
+      {
+        "id": "state-label-lg",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "state_label",
+        "minzoom": 3,
+        "maxzoom": 7,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "area",
+            80000
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "text-ignore-placement": false,
+          "text-max-size": 10,
+          "text-transform": "uppercase",
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "text-padding": 1,
+          "visibility": "visible",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "{abbr}"
+              ],
+              [
+                4,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-letter-spacing": 0.15,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                9
+              ],
+              [
+                7,
+                18
+              ]
+            ]
+          },
+          "text-opacity": 1,
+          "text-color": "@label-state",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1
+        }
+      },
+      {
+        "id": "state-label-md",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "state_label",
+        "minzoom": 3,
+        "maxzoom": 8,
+        "filter": [
+          "all",
+          [
+            "<",
+            "area",
+            80000
+          ],
+          [
+            ">=",
+            "area",
+            20000
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "text-ignore-placement": false,
+          "text-max-size": 10,
+          "text-transform": "uppercase",
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "visibility": "visible",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "{abbr}"
+              ],
+              [
+                5,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-letter-spacing": 0.15,
+          "text-max-width": 6
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                5,
+                9
+              ],
+              [
+                8,
+                16
+              ]
+            ]
+          },
+          "text-opacity": 1,
+          "text-color": "@label-state",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1
+        }
+      },
+      {
+        "id": "state-label-sm",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "state_label",
+        "minzoom": 3,
+        "maxzoom": 9,
+        "filter": [
+          "all",
+          [
+            "<",
+            "area",
+            20000
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "text-ignore-placement": false,
+          "text-max-size": 10,
+          "text-transform": "uppercase",
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "visibility": "visible",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                "{abbr}"
+              ],
+              [
+                6,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-letter-spacing": 0.15,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                9
+              ],
+              [
+                9,
+                14
+              ]
+            ]
+          },
+          "text-opacity": 1,
+          "text-color": "@label-state",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1
+        }
+      },
+      {
+        "id": "marine-label-lg-pt",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "marine_label",
+        "minzoom": 1,
+        "maxzoom": 4,
+        "filter": [
+          "all",
+          [
+            "in",
+            "labelrank",
+            1
+          ],
+          [
+            "==",
+            "$type",
+            "Point"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-width": 4,
+          "text-letter-spacing": 0.25,
+          "text-line-height": 1.5,
+          "text-max-size": 15,
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label-water",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                1,
+                12
+              ],
+              [
+                4,
+                30
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "marine-label-lg-ln",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "marine_label",
+        "minzoom": 1,
+        "maxzoom": 4,
+        "filter": [
+          "all",
+          [
+            "in",
+            "labelrank",
+            1
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-width": 4,
+          "text-letter-spacing": 0.25,
+          "text-line-height": 1.1,
+          "text-max-size": 15,
+          "symbol-placement": "line",
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label-water",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                1,
+                12
+              ],
+              [
+                4,
+                30
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "marine-label-md-pt",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "marine_label",
+        "minzoom": 2,
+        "maxzoom": 8,
+        "filter": [
+          "all",
+          [
+            "in",
+            "labelrank",
+            2,
+            3
+          ],
+          [
+            "==",
+            "$type",
+            "Point"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-width": 5,
+          "text-letter-spacing": 0.15,
+          "text-line-height": 1.5,
+          "text-max-size": 15,
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label-water",
+          "text-size": {
+            "base": 1.1,
+            "stops": [
+              [
+                2,
+                12
+              ],
+              [
+                5,
+                20
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "marine-label-md-ln",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "marine_label",
+        "minzoom": 2,
+        "maxzoom": 8,
+        "filter": [
+          "all",
+          [
+            "in",
+            "labelrank",
+            2,
+            3
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.1,
+          "symbol-min-distance": 250,
+          "text-max-size": 15,
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.15,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-color": "@label-water",
+          "text-size": {
+            "base": 1.1,
+            "stops": [
+              [
+                2,
+                10
+              ],
+              [
+                5,
+                20
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "marine-label-sm-pt",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "marine_label",
+        "minzoom": 3,
+        "maxzoom": 10,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "labelrank",
+            4
+          ],
+          [
+            "==",
+            "$type",
+            "Point"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-width": 5,
+          "text-letter-spacing": 0.1,
+          "text-line-height": 1.5,
+          "text-max-size": 15,
+          "symbol-placement": "point",
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-color": "@label-water",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                11
+              ],
+              [
+                6,
+                20
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "marine-label-sm-ln",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "marine_label",
+        "minzoom": 3,
+        "maxzoom": 10,
+        "filter": [
+          "all",
+          [
+            ">=",
+            "labelrank",
+            4
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.1,
+          "symbol-min-distance": {
+            "base": 1,
+            "stops": [
+              [
+                4,
+                100
+              ],
+              [
+                6,
+                400
+              ]
+            ]
+          },
+          "text-max-size": 15,
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.1,
+          "text-max-width": 5
+        },
+        "paint": {
+          "text-color": "@label-water",
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                3,
+                11
+              ],
+              [
+                6,
+                15
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place-city-lg-n",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 1,
+        "maxzoom": 14,
+        "filter": [
+          "all",
+          [
+            "<=",
+            "scalerank",
+            2
+          ],
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "in",
+            "ldir",
+            "N",
+            "NE",
+            "NW",
+            "W"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "icon-image": "circle",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "bottom"
+              ],
+              [
+                8,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                [
+                  0,
+                  -0.3
+                ]
+              ],
+              [
+                8,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "icon-max-size": 0.4,
+          "text-max-size": 20,
+          "text-font": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "Open Sans Regular, Arial Unicode MS Regular"
+              ],
+              [
+                8,
+                "Open Sans Semibold, Arial Unicode MS Bold"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-size": "@label-city-lg-size",
+          "text-color": "@label-primary",
+          "icon-halo-blur": 1,
+          "icon-halo-color": "@halo",
+          "icon-halo-width": 1,
+          "text-opacity": 1,
+          "icon-color": "@label-primary",
+          "text-halo-color": "@halo",
+          "icon-size": 0.4,
+          "text-halo-width": 1,
+          "icon-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                1
+              ],
+              [
+                8,
+                0
+              ]
+            ]
+          },
+          "text-halo-blur": 1
+        }
+      },
+      {
+        "id": "place-city-lg-s",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 1,
+        "maxzoom": 14,
+        "filter": [
+          "all",
+          [
+            "<=",
+            "scalerank",
+            2
+          ],
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "in",
+            "ldir",
+            "S",
+            "SE",
+            "SW",
+            "E"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "icon-image": "circle",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "top"
+              ],
+              [
+                8,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                [
+                  0,
+                  0.15
+                ]
+              ],
+              [
+                8,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "icon-max-size": 0.4,
+          "text-max-size": 20,
+          "text-font": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "Open Sans Regular, Arial Unicode MS Regular"
+              ],
+              [
+                8,
+                "Open Sans Semibold, Arial Unicode MS Bold"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-size": "@label-city-lg-size",
+          "text-color": "@label-primary",
+          "icon-halo-blur": 1,
+          "icon-halo-color": "@halo",
+          "icon-halo-width": 1,
+          "icon-color": "@label-primary",
+          "text-halo-color": "@halo",
+          "icon-size": 0.4,
+          "text-halo-width": 1,
+          "icon-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                1
+              ],
+              [
+                8,
+                0
+              ]
+            ]
+          },
+          "text-halo-blur": 1
+        }
+      },
+      {
+        "id": "place-city-md-n",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 0,
+        "maxzoom": 14,
+        "filter": [
+          "all",
+          [
+            "in",
+            "scalerank",
+            3,
+            4,
+            5
+          ],
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "in",
+            "ldir",
+            "N",
+            "NE",
+            "NW",
+            "W"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "icon-image": "circle",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "bottom"
+              ],
+              [
+                8,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                [
+                  0,
+                  -0.25
+                ]
+              ],
+              [
+                8,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "icon-max-size": 0.35,
+          "text-max-size": 20,
+          "text-font": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "Open Sans Regular, Arial Unicode MS Regular"
+              ],
+              [
+                8,
+                "Open Sans Semibold, Arial Unicode MS Bold"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-size": "@label-city-md-size",
+          "text-color": "@label-primary",
+          "icon-halo-blur": 1,
+          "icon-halo-color": "@halo",
+          "icon-halo-width": 1,
+          "icon-color": "@label-primary",
+          "text-halo-color": "@halo",
+          "icon-size": 0.35,
+          "text-halo-width": 1,
+          "icon-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                1
+              ],
+              [
+                8,
+                0
+              ]
+            ]
+          },
+          "text-halo-blur": 1
+        }
+      },
+      {
+        "id": "place-city-md-s",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 0,
+        "maxzoom": 14,
+        "filter": [
+          "all",
+          [
+            "in",
+            "scalerank",
+            3,
+            4,
+            5
+          ],
+          [
+            "==",
+            "type",
+            "city"
+          ],
+          [
+            "in",
+            "ldir",
+            "S",
+            "SE",
+            "WW",
+            "E"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "icon-image": "circle",
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "top"
+              ],
+              [
+                8,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                [
+                  0,
+                  0.1
+                ]
+              ],
+              [
+                8,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "icon-max-size": 0.35,
+          "text-max-size": 20,
+          "text-font": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "Open Sans Regular, Arial Unicode MS Regular"
+              ],
+              [
+                8,
+                "Open Sans Semibold, Arial Unicode MS Bold"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "icon-size": 0.35,
+          "text-size": "@label-city-md-size",
+          "text-halo-width": 1,
+          "text-halo-color": "@halo",
+          "text-color": "@label-primary",
+          "text-halo-blur": 1,
+          "icon-color": "@label-primary",
+          "icon-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                1
+              ],
+              [
+                8,
+                0
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place-city-sm",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 0,
+        "maxzoom": 14,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "scalerank",
+            0,
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          [
+            "==",
+            "type",
+            "city"
+          ]
+        ],
+        "layout": {
+          "icon-image": "circle",
+          "text-max-size": 20,
+          "text-transform": "none",
+          "text-font": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "Open Sans Regular, Arial Unicode MS Regular"
+              ],
+              [
+                8,
+                "Open Sans Semibold, Arial Unicode MS Bold"
+              ]
+            ]
+          },
+          "visibility": "visible",
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                [
+                  0,
+                  -0.2
+                ]
+              ],
+              [
+                8,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "bottom"
+              ],
+              [
+                8,
+                "center"
+              ]
+            ]
+          },
+          "text-field": "{name_en}",
+          "icon-max-size": 0.3
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                6,
+                11
+              ],
+              [
+                14,
+                20
+              ]
+            ]
+          },
+          "text-color": "@label-primary",
+          "icon-halo-blur": 1,
+          "icon-halo-color": "@halo",
+          "icon-halo-width": 1,
+          "icon-color": "@label-primary",
+          "text-halo-color": "@halo",
+          "icon-size": 0.3,
+          "text-halo-width": 1.25,
+          "icon-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                1
+              ],
+              [
+                8,
+                0
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-islands",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "Island"
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 14,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            0
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "center",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 8
+        },
+        "paint": {
+          "text-color": "@label-poi",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                14
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place-town",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 6,
+        "maxzoom": 14,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "town"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-size": 18,
+          "icon-image": "circle",
+          "icon-max-size": 0.3,
+          "text-anchor": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                "bottom"
+              ],
+              [
+                8,
+                "center"
+              ]
+            ]
+          },
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                [
+                  0,
+                  -0.15
+                ]
+              ],
+              [
+                8,
+                [
+                  0,
+                  0
+                ]
+              ]
+            ]
+          },
+          "text-font": {
+            "base": 1,
+            "stops": [
+              [
+                11,
+                "Open Sans Regular, Arial Unicode MS Regular"
+              ],
+              [
+                12,
+                "Open Sans Semibold, Arial Unicode MS Bold"
+              ]
+            ]
+          }
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                7,
+                11
+              ],
+              [
+                15,
+                18
+              ]
+            ]
+          },
+          "text-color": "@label-primary",
+          "icon-halo-blur": 1,
+          "icon-halo-color": "@halo",
+          "icon-halo-width": 1,
+          "icon-color": "@label-primary",
+          "text-halo-color": "@halo",
+          "icon-size": 0.3,
+          "text-halo-width": 1.25,
+          "icon-opacity": {
+            "base": 1,
+            "stops": [
+              [
+                7.99,
+                1
+              ],
+              [
+                8,
+                0
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "place-village",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 8,
+        "maxzoom": 15,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "village"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-size": 16
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                11
+              ],
+              [
+                16,
+                16
+              ]
+            ]
+          },
+          "text-halo-color": "@halo",
+          "text-halo-width": 1.25,
+          "text-color": "@label-primary"
+        }
+      },
+      {
+        "id": "place-hamlet",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 10,
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "hamlet"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-size": 14
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                12,
+                11
+              ],
+              [
+                15,
+                14
+              ]
+            ]
+          },
+          "text-halo-color": "@halo",
+          "text-halo-width": 1.25,
+          "text-color": "@label-primary"
+        }
+      },
+      {
+        "id": "place-suburb",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 10,
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "==",
+            "type",
+            "suburb"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-transform": "uppercase",
+          "text-max-size": 14,
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "text-letter-spacing": 0.15,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                11,
+                10
+              ],
+              [
+                15,
+                16
+              ]
+            ]
+          },
+          "text-halo-color": "@halo",
+          "text-halo-width": 1.25,
+          "text-color": "@label-neighbourhood"
+        }
+      },
+      {
+        "id": "place-neighbourhood",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "place_label",
+        "minzoom": 10,
+        "maxzoom": 16,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "neighbourhood"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "text-max-size": 14,
+          "text-transform": "uppercase",
+          "text-letter-spacing": 0.1,
+          "text-max-width": 7,
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                12,
+                10
+              ],
+              [
+                16,
+                14
+              ]
+            ]
+          },
+          "text-halo-color": "@halo",
+          "text-halo-width": 1.25,
+          "text-color": "@label-neighbourhood"
+        }
+      },
+      {
+        "id": "poi-islets",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "Islet"
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 14,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            0
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "center",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 8
+        },
+        "paint": {
+          "text-color": "@label-poi",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                14,
+                14
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "water-label",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "water_label",
+        "minzoom": 5,
+        "maxzoom": 22,
+        "filter": [
+          "all"
+        ],
+        "layout": {
+          "text-field": "{name_en}",
+          "visibility": "visible",
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular"
+        },
+        "paint": {
+          "text-halo-width": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                12
+              ],
+              [
+                18,
+                16
+              ]
+            ]
+          },
+          "text-halo-color": "@halo",
+          "text-color": "@label-water-dark",
+          "text-halo-blur": 1.5
+        }
+      },
+      {
+        "id": "airport-label",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 9,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "airport",
+            "heliport",
+            "rocket"
+          ],
+          [
+            "<=",
+            "scalerank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": {
+            "stops": [
+              [
+                12,
+                "{maki}-11"
+              ],
+              [
+                13,
+                "{maki}-15"
+              ]
+            ]
+          },
+          "text-ignore-placement": false,
+          "text-max-size": 18,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-offset": {
+            "base": 1,
+            "stops": [
+              [
+                12,
+                [
+                  0,
+                  1
+                ]
+              ],
+              [
+                13,
+                [
+                  0,
+                  1.25
+                ]
+              ]
+            ]
+          },
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": {
+            "stops": [
+              [
+                12,
+                "{ref}"
+              ],
+              [
+                13,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-letter-spacing": 0.02,
+          "text-max-width": 9
+        },
+        "paint": {
+          "text-color": "@label-transit",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1.25,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                18
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-scalerank1",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail",
+            "airport",
+            "airfield",
+            "heliport",
+            "rocket",
+            "park",
+            "golf",
+            "cemetery",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "<=",
+            "scalerank",
+            1
+          ],
+          [
+            "!=",
+            "type",
+            "Island"
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": {
+            "stops": [
+              [
+                13,
+                "{maki}-11"
+              ],
+              [
+                14,
+                "{maki}-15"
+              ]
+            ]
+          },
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 14,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 8
+        },
+        "paint": {
+          "text-color": "@label-poi",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                14
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-parks-scalerank1",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "park",
+            "golf",
+            "cemetery",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "<=",
+            "scalerank",
+            1
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": {
+            "stops": [
+              [
+                13,
+                "{maki}-11"
+              ],
+              [
+                14,
+                "{maki}-15"
+              ]
+            ]
+          },
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 14,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 8
+        },
+        "paint": {
+          "text-color": "@label-park",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-halo-blur": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                10
+              ],
+              [
+                18,
+                14
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "interstate_motorway_shields",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "shield",
+            "us-interstate",
+            "us-interstate-business",
+            "us-interstate-duplex"
+          ],
+          [
+            "<=",
+            "reflen",
+            6
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "symbol-min-distance": 1000,
+          "icon-image": {
+            "stops": [
+              [
+                15,
+                "{shield}-{reflen}-small"
+              ],
+              [
+                16,
+                "{shield}-{reflen}-large"
+              ]
+            ]
+          },
+          "icon-rotation-alignment": "viewport",
+          "symbol-avoid-edges": false,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 11,
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "symbol-placement": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                "point"
+              ],
+              [
+                11,
+                "line"
+              ]
+            ]
+          },
+          "text-padding": 20,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{ref}",
+          "text-letter-spacing": 0.05,
+          "icon-padding": 20
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                15.95,
+                9
+              ],
+              [
+                16,
+                11
+              ]
+            ]
+          },
+          "text-color": "#fff",
+          "icon-halo-color": "rgba(0, 0, 0, 1)",
+          "icon-halo-width": 1,
+          "text-opacity": 1,
+          "icon-color": "white",
+          "text-halo-color": "@halo",
+          "text-halo-width": 0
+        }
+      },
+      {
+        "id": "other-motorway-shields",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "shield",
+            "us-interstate",
+            "us-interstate-business",
+            "us-interstate-duplex"
+          ],
+          [
+            "<=",
+            "reflen",
+            6
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "symbol-min-distance": 1000,
+          "icon-image": {
+            "stops": [
+              [
+                15,
+                "{shield}-{reflen}-small"
+              ],
+              [
+                16,
+                "{shield}-{reflen}-large"
+              ]
+            ]
+          },
+          "icon-rotation-alignment": "viewport",
+          "symbol-avoid-edges": false,
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 11,
+          "text-font": "Open Sans Bold, Arial Unicode MS Regular",
+          "symbol-placement": {
+            "base": 1,
+            "stops": [
+              [
+                10,
+                "point"
+              ],
+              [
+                11,
+                "line"
+              ]
+            ]
+          },
+          "text-padding": 20,
+          "visibility": "visible",
+          "text-rotation-alignment": "viewport",
+          "text-field": "{ref}",
+          "text-letter-spacing": 0.05,
+          "icon-padding": 20
+        },
+        "paint": {
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                15.95,
+                9
+              ],
+              [
+                16,
+                11
+              ]
+            ]
+          },
+          "text-color": "@label-road",
+          "icon-halo-color": "rgba(0, 0, 0, 1)",
+          "icon-halo-width": 1,
+          "text-opacity": 1,
+          "icon-color": "white",
+          "text-halo-color": "@halo",
+          "text-halo-width": 0
+        }
+      },
+      {
+        "id": "road-label-large",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road_label",
+        "minzoom": 0,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "main",
+            "motorway"
+          ]
+        ],
+        "layout": {
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "text-ignore-placement": false,
+          "text-max-angle": 30,
+          "text-max-size": 16,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-rotation-alignment": "map",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.01
+        },
+        "paint": {
+          "text-color": "@label-road",
+          "text-halo-color": "rgba(255,255,255, 0.75)",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                9,
+                10
+              ],
+              [
+                20,
+                16
+              ]
+            ]
+          },
+          "text-halo-blur": 1
+        }
+      },
+      {
+        "id": "rail-label",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "type",
+            "Rail Station"
+          ]
+        ],
+        "layout": {
+          "symbol-min-distance": 250,
+          "icon-image": "{network}-11",
+          "symbol-avoid-edges": true,
+          "text-max-size": 12,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "icon-allow-overlap": false,
+          "symbol-placement": "point",
+          "text-justify": "center",
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            0.75
+          ],
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": {
+            "base": 1,
+            "stops": [
+              [
+                0,
+                ""
+              ],
+              [
+                14,
+                "{name_en}"
+              ]
+            ]
+          },
+          "text-letter-spacing": 0.02,
+          "icon-padding": 0,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@label-transit",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1.5,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                10
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          },
+          "icon-halo-width": 4,
+          "icon-halo-color": "#fff"
+        }
+      },
+      {
+        "id": "poi-parks-scalerank2",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "park",
+            "golf",
+            "cemetery",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "==",
+            "scalerank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": {
+            "stops": [
+              [
+                14,
+                "{maki}-11"
+              ],
+              [
+                15,
+                "{maki}-15"
+              ]
+            ]
+          },
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 14,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1.25
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 8
+        },
+        "paint": {
+          "text-color": "@label-park",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1.25,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                10
+              ],
+              [
+                20,
+                14
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-scalerank2",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail",
+            "airport",
+            "airfield",
+            "heliport",
+            "rocket",
+            "park",
+            "golf",
+            "cemetery",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "==",
+            "scalerank",
+            2
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": {
+            "stops": [
+              [
+                14,
+                "{maki}-11"
+              ],
+              [
+                15,
+                "{maki}-15"
+              ]
+            ]
+          },
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 14,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1.25
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 8
+        },
+        "paint": {
+          "text-color": "@label-poi",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1.25,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                14,
+                10
+              ],
+              [
+                20,
+                14
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-label-medium",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road_label",
+        "minzoom": 11,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "class",
+            "street",
+            "street_limited"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{name_en}",
+          "symbol-placement": "line",
+          "text-rotation-alignment": "map",
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "text-max-angle": 30,
+          "text-padding": 0,
+          "text-letter-spacing": 0.01
+        },
+        "paint": {
+          "text-color": "@label-road",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                11,
+                10
+              ],
+              [
+                20,
+                14
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "road-label-small",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "road_label",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "class",
+            "motorway",
+            "main",
+            "street_limited",
+            "street"
+          ],
+          [
+            "==",
+            "$type",
+            "LineString"
+          ]
+        ],
+        "layout": {
+          "text-ignore-placement": false,
+          "text-max-angle": 30,
+          "text-max-size": 12,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "line",
+          "text-padding": 0,
+          "visibility": "visible",
+          "text-rotation-alignment": "map",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.01
+        },
+        "paint": {
+          "text-color": "@label-road",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1.25,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                9
+              ],
+              [
+                20,
+                12
+              ]
+            ]
+          },
+          "text-halo-blur": 1
+        }
+      },
+      {
+        "id": "poi-parks-scalerank3",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "park",
+            "cemetery",
+            "golf",
+            "zoo"
+          ],
+          [
+            "==",
+            "scalerank",
+            3
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "{maki}-11",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 13,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 2,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@label-park",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                10
+              ],
+              [
+                20,
+                13
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-scalerank3",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 15,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail",
+            "airport",
+            "airfield",
+            "heliport",
+            "rocket",
+            "park",
+            "golf",
+            "cemetery",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "==",
+            "scalerank",
+            3
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "{maki}-11",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 13,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 1,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@label-poi",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                10
+              ],
+              [
+                20,
+                13
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-parks_scalerank4",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 16,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "in",
+            "maki",
+            "park",
+            "cemetery",
+            "golf",
+            "zoo",
+            "playground",
+            ""
+          ],
+          [
+            "==",
+            "scalerank",
+            4
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "{maki}-11",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 13,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 1,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@label-park",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                10
+              ],
+              [
+                20,
+                13
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-scalerank4-l1",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 16,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail",
+            "airport",
+            "airfield",
+            "heliport",
+            "rocket",
+            "park",
+            "golf",
+            "cemetery",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "==",
+            "scalerank",
+            4
+          ],
+          [
+            "<=",
+            "localrank",
+            14
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "{maki}-11",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 13,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 1,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@label-poi",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                10
+              ],
+              [
+                20,
+                13
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "poi-scalerank4-l15",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "poi_label",
+        "minzoom": 17,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "!in",
+            "maki",
+            "rail-light",
+            "rail-metro",
+            "rail",
+            "airport",
+            "airfield",
+            "heliport",
+            "rocket",
+            "park",
+            "golf",
+            "cemetery",
+            "zoo",
+            "campsite",
+            "swimming",
+            "dog-park"
+          ],
+          [
+            "==",
+            "scalerank",
+            4
+          ],
+          [
+            ">=",
+            "localrank",
+            15
+          ]
+        ],
+        "layout": {
+          "text-line-height": 1.2,
+          "text-allow-overlap": false,
+          "symbol-min-distance": 250,
+          "icon-image": "{maki}-11",
+          "text-ignore-placement": false,
+          "text-max-angle": 38,
+          "text-max-size": 13,
+          "text-font": "Open Sans Regular, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-padding": 1,
+          "visibility": "visible",
+          "text-offset": [
+            0,
+            1
+          ],
+          "icon-optional": false,
+          "text-rotation-alignment": "viewport",
+          "text-anchor": "top",
+          "text-field": "{name_en}",
+          "text-letter-spacing": 0.02,
+          "text-max-width": 7
+        },
+        "paint": {
+          "text-color": "@label-poi",
+          "text-halo-color": "@halo",
+          "text-halo-width": 1,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                16,
+                10
+              ],
+              [
+                20,
+                13
+              ]
+            ]
+          }
+        }
+      },
+      {
+        "id": "waterway-label",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "waterway_label",
+        "minzoom": 12,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "class",
+            "river"
+          ]
+        ],
+        "layout": {
+          "text-field": "{name_en}",
+          "visibility": "visible",
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular",
+          "symbol-placement": "line"
+        },
+        "paint": {
+          "text-halo-width": 0,
+          "text-size": {
+            "base": 1,
+            "stops": [
+              [
+                13,
+                12
+              ],
+              [
+                18,
+                16
+              ]
+            ]
+          },
+          "text-halo-color": "@halo",
+          "text-color": "@label-water-dark",
+          "text-halo-blur": 1.5
+        }
+      },
+      {
+        "id": "contour-index-label",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-terrain-v2",
+        "source-layer": "contour",
+        "minzoom": 13,
+        "maxzoom": 22,
+        "filter": [
+          "all",
+          [
+            "==",
+            "index",
+            5
+          ]
+        ],
+        "layout": {
+          "text-field": "{ele} m",
+          "symbol-placement": "line",
+          "text-max-size": 9,
+          "text-max-angle": 25,
+          "visibility": "visible",
+          "text-padding": 5
+        },
+        "paint": {
+          "text-size": 9,
+          "text-color": "#909166",
+          "text-halo-width": 1,
+          "text-halo-blur": 1,
+          "text-halo-color": "rgba(255,255,237, 0.25)"
+        }
+      },
+      {
+        "id": "housenum-label",
+        "type": "symbol",
+        "source": "mapbox://mapbox.mapbox-streets-v6",
+        "source-layer": "housenum_label",
+        "minzoom": 17,
+        "maxzoom": 22,
+        "layout": {
+          "visibility": "visible",
+          "text-field": "{house_num}",
+          "text-font": "Open Sans Italic, Arial Unicode MS Regular",
+          "symbol-placement": "point",
+          "text-max-size": 9,
+          "text-padding": 4
+        },
+        "paint": {
+          "text-size": 9,
+          "text-color": "#b2aca5",
+          "text-halo-color": "@building",
+          "text-halo-width": 1.5,
+          "text-halo-blur": 0
+        }
+      }
+    ],
+    "owner": "nicki",
+    "modified": "2015-04-10T00:47:59.077Z",
+    "created": "2015-04-09T15:07:45.431Z",
+    "id": "nicki.d51cce27"
   },
   "outdoors": {
     "version": 7,
@@ -3522,7 +23925,7 @@
     "sources": {
       "mapbox": {
         "type": "vector",
-        "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6-dev"
+        "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6"
       }
     },
     "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/outdoors",
@@ -5820,20 +26223,6 @@
         }
       },
       {
-        "id": "country_label_line",
-        "type": "line",
-        "source": "mapbox",
-        "source-layer": "country_label_line",
-        "paint": {
-          "line-color": "@country_text",
-          "line-width": 0.5,
-          "line-opacity": 0.5
-        },
-        "paint.night": {
-          "line-color": "@text_night"
-        }
-      },
-      {
         "id": "country_label",
         "type": "symbol",
         "source": "mapbox",
@@ -6902,7 +27291,7 @@
     "sources": {
       "mapbox": {
         "type": "vector",
-        "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6-dev"
+        "url": "mapbox://mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v6"
       }
     },
     "sprite": "https://www.mapbox.com/mapbox-gl-styles/sprites/pencil",
@@ -8179,7 +28568,7 @@
     "sources": {
       "mapbox": {
         "type": "vector",
-        "url": "mapbox://mapbox.mapbox-streets-v6-dev"
+        "url": "mapbox://mapbox.mapbox-streets-v6"
       },
       "satellite": {
         "type": "raster",


### PR DESCRIPTION
I didn't realize `index.js` wasn't the canonical source for styles in `index.html`, so this *actually* updates the styles used in the `mb-pages` demo.

See original PR #113.