### PR TITLE
Dark style's road T-junctions have slight nubbins at high zoom

### DIFF
--- a/styles/dark-v7.json
+++ b/styles/dark-v7.json
@@ -52,7 +52,7 @@
     "@scrub": "#1c1c1c",
     "@crop": "#131313",
     "@label-waterway": "#929292",
-    "@main-width": {
+    "@road-main-width": {
       "base": 1.5,
       "stops": [[6, 0.5], [18, 26]]
     },
@@ -83,10 +83,6 @@
     "@path-width": {
       "base": 1.5,
       "stops": [[15, 1], [18, 4]]
-    },
-    "@road-main-width": {
-      "base": 1.4,
-      "stops": [[6, 0.25], [20, 25]]
     }
   },
   "sources": {
@@ -756,7 +752,7 @@
     },
     "paint": {
       "line-color": "@road-major",
-      "line-width": "@main-width",
+      "line-width": "@road-main-width",
       "line-opacity": "@road-high-z-fadein"
     }
   }, {

--- a/styles/light-v7.json
+++ b/styles/light-v7.json
@@ -52,7 +52,7 @@
     "@scrub": "#e3e3e3",
     "@crop": "#ececec",
     "@label-waterway": "#929292",
-    "@main-width": {
+    "@road-main-width": {
       "base": 1.5,
       "stops": [[6, 0.5], [18, 26]]
     },
@@ -83,10 +83,6 @@
     "@path-width": {
       "base": 1.5,
       "stops": [[15, 1], [18, 4]]
-    },
-    "@road-main-width": {
-      "base": 1.4,
-      "stops": [[6, 0.25], [20, 30]]
     }
   },
   "sources": {
@@ -568,7 +564,7 @@
     },
     "paint": {
       "line-color": "@road-major",
-      "line-width": "@main-width",
+      "line-width": "@road-main-width",
       "line-opacity": "@road-high-z-fadein"
     }
   }, {
@@ -759,7 +755,7 @@
     },
     "paint": {
       "line-color": "@road-major",
-      "line-width": "@main-width",
+      "line-width": "@road-main-width",
       "line-opacity": "@road-high-z-fadein"
     }
   }, {


### PR DESCRIPTION
In the Dark style, tertiary/main roads aren't being scaled in sync with other roads, which results in T-junctions with lesser roads overlapping and showing little bumps. Light doesn't have this problem because it uses `@main-width` instead of `@road-main-width`.

Because of the design workflow I don't know if this PR will be useful per se, but here are the changes to Dark and Light I would suggest:

**Dark**
- Delete wrong, duplicate `@road-main-width`
- Use `@main-width` (like in Light), rename it to `@road-main-width`

**Light**
- Delete unused `@road-main-width`
- Rename `@main-width` to `@road-main-width`

![screen shot 2015-04-25 at 4 09 52 pm](https://cloud.githubusercontent.com/assets/1198851/7335273/fcd67cc6-eb67-11e4-80bf-76000b934343.png)
![screen shot 2015-04-25 at 4 09 56 pm](https://cloud.githubusercontent.com/assets/1198851/7335274/fcf58530-eb67-11e4-931d-a261a28f2730.png)

https://www.mapbox.com/mapbox-gl-styles/#17.92/45.53007/-122.99799

/cc @andreasviglakis