### PR TITLE
support for browserify and version bump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "mapbox-gl-styles",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "mapbox gl example styles",
-  "main": "index.js",
+  "main": "index.json",
   "bin": {},
   "scripts": {
     "test": "gl-style-validate styles/*-v7.json",


### PR DESCRIPTION
Because the require statements in index.js are computed dynamically, they can't be used in browserify. A quick fix is to just use the built index.json file instead. I also bumped the npm version number. Could you republish to npm? The version on npm is outdated.