### PR TITLE
Use gl-js v0.9.0 instead of master

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
     <meta charset='utf-8' />
     <title>Mapbox GL Styles</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src='https://mapbox.s3.amazonaws.com/mapbox-gl-js/master/mapbox-gl-dev.js'></script>
+    <script src='https://mapbox.s3.amazonaws.com/mapbox-gl-js/v0.9.0/mapbox-gl-dev.js'></script>
     <link href='https://www.mapbox.com/base/latest/base.css' rel='stylesheet' />
-    <link href='https://mapbox.s3.amazonaws.com/mapbox-gl-js/master/mapbox-gl.css' rel='stylesheet' />
+    <link href='https://mapbox.s3.amazonaws.com/mapbox-gl-js/v0.9.0/mapbox-gl.css' rel='stylesheet' />
 
     <style>
         body { margin:0; padding:0; }


### PR DESCRIPTION
The mb-pages branch on www.mapbox.com should be pinned to a stable version of Mapbox GL JS that supports the included styles.

ref #157

/cc @jfirebaugh