### PR TITLE
Streets: fixed country-label-lg filters

### DIFF
--- a/styles/streets-v8.json
+++ b/styles/streets-v8.json
@@ -8495,17 +8495,10 @@
             },
             "maxzoom": 7,
             "filter": [
-                "all",
-                [
-                    "==",
-                    "oneway",
-                    1
-                ],
-                [
-                    "==",
-                    "type",
-                    "trunk"
-                ]
+                "in",
+                "scalerank",
+                1,
+                2
             ],
             "type": "symbol",
             "source": "composite",


### PR DESCRIPTION
Found a weird bug in the Streets style (the filters for one of the layers got transposed onto a different layer). Fixes large country labels not showing up.