### PR TITLE
fix contour filters to actually filter every 5th line

### DIFF
--- a/styles/streets-v8.json
+++ b/styles/streets-v8.json
@@ -5678,9 +5678,11 @@
             "source": "composite",
             "source-layer": "contour",
             "filter": [
-                "!=",
+                "!in",
                 "index",
-                5
+                -1,
+                5,
+                10
             ],
             "minzoom": 14,
             "layout": {
@@ -5702,7 +5704,8 @@
             "filter": [
                 "==",
                 "index",
-                5
+                5,
+                10
             ],
             "minzoom": 14,
             "layout": {
@@ -5749,7 +5752,8 @@
             "filter": [
                 "==",
                 "index",
-                5
+                5,
+                10
             ],
             "minzoom": 14,
             "layout": {


### PR DESCRIPTION
@nickidlugash @samanpwbb 

I'm assuming the intention of the existing `"filter": ["==", "index", 5]` is to select every fifth line, but the correct filter to do that is actually `"filter": ["in", "index", 5, 10]` since every 10th line also part of the every-5th-line sequence.

This PR should fix that.