### PR TITLE
emerald style ensure all hillshade layers fade out at z15

### DIFF
--- a/styles/emerald-v7.json
+++ b/styles/emerald-v7.json
@@ -1108,7 +1108,7 @@
       "source": "compositedsource",
       "source-layer": "hillshade",
       "minzoom": 0,
-      "maxzoom": 22,
+      "maxzoom": 15,
       "interactive": true,
       "filter": [
         "all",

--- a/styles/emerald-v8.json
+++ b/styles/emerald-v8.json
@@ -690,9 +690,22 @@
                 "level",
                 94
             ],
+            "maxzoom": 15,
             "paint": {
                 "fill-color": "#fff",
-                "fill-opacity": 0.2
+                "fill-opacity": {
+                    "base": 1,
+                    "stops": [
+                        [
+                            14,
+                            0.2
+                        ],
+                        [
+                            15,
+                            0
+                        ]
+                    ]
+                }
             },
             "metadata": {
                 "mapbox:group": "1444858181796.6055"


### PR DESCRIPTION
in the emerald style, all the Hillshades layers are set to fade out and disappear after z15, probably because the hillshading data looses detail after this, however highlight_medium doesn't disappear. This change fixes that.