### PR TITLE
satellite style updated to mbsv7, ready to merge

### DIFF
--- a/sprites/satellite-hybrid-v8/satellite-v8
+++ b/sprites/satellite-hybrid-v8/satellite-v8
@@ -1,1 +1,0 @@
-sprites/satellite-v8

--- a/sprites/satellite-hybrid-v8/satellite-v8
+++ b/sprites/satellite-hybrid-v8/satellite-v8
@@ -1,0 +1,1 @@
+sprites/satellite-v8

--- a/sprites/satellite-v8
+++ b/sprites/satellite-v8
@@ -1,0 +1,1 @@
+satellite-hybrid-v8

--- a/styles/satellite-v8.json
+++ b/styles/satellite-v8.json
@@ -8,6 +8,8 @@
       "tileSize": 256
     }
   },
+  "sprite": "mapbox://sprites/mapbox/satellite-v8",
+  "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",


### PR DESCRIPTION
Per https://github.com/mapbox/mapbox-gl-styles/issues/241#issuecomment-186025034, adding default `sprite` and `glyph` to `satellite-v8` as part of streets-v7 Studio update https://github.com/mapbox/mapbox-gl-styles/issues/249.

/cc @samanpwbb @jfirebaugh @lucaswoj 

