### PR TITLE
remove sand-noise

### DIFF
--- a/styles/emerald-v8.json
+++ b/styles/emerald-v8.json
@@ -338,8 +338,7 @@
             "id": "sand",
             "paint": {
                 "fill-color": "#f1f0d2",
-                "fill-opacity": 1,
-                "fill-pattern": "sand_noise"
+                "fill-opacity": 1
             },
             "source-layer": "landuse"
         },


### PR DESCRIPTION
solves https://github.com/mapbox/mapbox-gl-styles/issues/288

This was a texture from an old version of the style that is no longer used, so it has been failing silently.

cc/ @amyleew 