### PR TITLE
Updates to gl-styles for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.10
+
+- bright-v8 style: Add motorway icons
+- satellite-hybrid-v8 style: update json to reference `motorway_{reflen}`
+
+
 ## v1.2.9
 
 - Fix for emerald-v8 style owner setting

--- a/sprites/satellite-hybrid-v8/_svg/motorway_1.svg
+++ b/sprites/satellite-hybrid-v8/_svg/motorway_1.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 18 18"
+   version="1.1"
+   id="svg4986"
+   height="18"
+   width="18">
+  <defs
+     id="defs4988" />
+  <metadata
+     id="metadata4991">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-53.499985,-902.86218)"
+     id="layer1">
+    <g
+       id="generic-md-1"
+       transform="translate(-180,480)">
+      <rect
+         rx="2.4000025"
+         ry="2.4000025"
+         y="422.86218"
+         x="233.49998"
+         height="18"
+         width="18"
+         id="rect3443"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#3a3836;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.20000005;marker:none;enable-background:accumulate" />
+      <rect
+         rx="1.2307723"
+         ry="1.2307742"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.23077071;marker:none;enable-background:accumulate"
+         id="rect3445"
+         width="16.000006"
+         height="16.000031"
+         x="234.49998"
+         y="423.86218" />
+    </g>
+  </g>
+</svg>

--- a/sprites/satellite-hybrid-v8/_svg/motorway_2.svg
+++ b/sprites/satellite-hybrid-v8/_svg/motorway_2.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 25 18"
+   version="1.1"
+   id="svg5037"
+   height="18"
+   width="25">
+  <defs
+     id="defs5039" />
+  <metadata
+     id="metadata5042">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-54.999985,-921.36219)"
+     id="layer1">
+    <g
+       id="generic-md-2"
+       transform="translate(-180,480)">
+      <rect
+         transform="translate(0,-1.5169706e-4)"
+         rx="2.3809547"
+         ry="2.4000025"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#3a3836;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.1952287;marker:none;enable-background:accumulate"
+         id="rect3449"
+         width="25"
+         height="18"
+         x="234.99998"
+         y="441.36218" />
+      <rect
+         rx="1.210529"
+         ry="1.2307718"
+         y="442.36218"
+         x="235.99998"
+         height="16"
+         width="23"
+         id="rect3451"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.22060561;marker:none;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/sprites/satellite-hybrid-v8/_svg/motorway_3.svg
+++ b/sprites/satellite-hybrid-v8/_svg/motorway_3.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 32.400002 18"
+   version="1.1"
+   id="svg5088"
+   height="18"
+   width="32.400002">
+  <defs
+     id="defs5090" />
+  <metadata
+     id="metadata5093">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-54.999985,-941.36218)"
+     id="layer1">
+    <g
+       id="generic-md-3"
+       transform="translate(-180,480)">
+      <rect
+         rx="2.4000025"
+         ry="2.4000025"
+         y="461.36218"
+         x="234.99998"
+         height="18"
+         width="32.400002"
+         id="rect3455"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#3a3836;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.20000005;marker:none;enable-background:accumulate" />
+      <rect
+         rx="1.2000027"
+         ry="1.2307718"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.21528721;marker:none;enable-background:accumulate"
+         id="rect3457"
+         width="30"
+         height="15.999998"
+         x="235.99998"
+         y="462.36218" />
+    </g>
+  </g>
+</svg>

--- a/sprites/satellite-hybrid-v8/_svg/motorway_4.svg
+++ b/sprites/satellite-hybrid-v8/_svg/motorway_4.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 39 18"
+   version="1.1"
+   id="svg5088"
+   height="18"
+   width="39">
+  <defs
+     id="defs5090" />
+  <metadata
+     id="metadata5093">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-54.999985,-941.36218)"
+     id="layer1">
+    <g
+       id="generic-md-3"
+       transform="translate(-180,480)">
+      <rect
+         rx="2.3636391"
+         ry="2.4000025"
+         y="461.36218"
+         x="234.99998"
+         height="18"
+         width="39"
+         id="rect3455"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#3a3836;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.19087458;marker:none;enable-background:accumulate" />
+      <rect
+         rx="1.1935509"
+         ry="1.2307712"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.21201575;marker:none;enable-background:accumulate"
+         id="rect3457"
+         width="37"
+         height="15.999991"
+         x="235.99998"
+         y="462.36218" />
+    </g>
+  </g>
+</svg>

--- a/sprites/satellite-hybrid-v8/_svg/motorway_5.svg
+++ b/sprites/satellite-hybrid-v8/_svg/motorway_5.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 45 18"
+   version="1.1"
+   id="svg5088"
+   height="18"
+   width="45">
+  <defs
+     id="defs5090" />
+  <metadata
+     id="metadata5093">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-55,-941.36218)"
+     id="layer1">
+    <g
+       id="generic-md-3"
+       transform="translate(-180,480)">
+      <rect
+         rx="2.9999888"
+         ry="2.9999888"
+         y="461.36218"
+         x="235"
+         height="18"
+         width="45"
+         id="rect3455"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#3a3836;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.19755852;marker:none;enable-background:accumulate" />
+      <rect
+         rx="1.9999888"
+         ry="1.9999888"
+         style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.21788085;marker:none;enable-background:accumulate"
+         id="rect3457"
+         width="43"
+         height="15.999989"
+         x="235.99998"
+         y="462.36218" />
+    </g>
+  </g>
+</svg>

--- a/sprites/satellite-hybrid-v8/_svg/motorway_6.svg
+++ b/sprites/satellite-hybrid-v8/_svg/motorway_6.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 50 18"
+   version="1.1"
+   id="svg5088"
+   height="18"
+   width="50">
+  <defs
+     id="defs5090" />
+  <metadata
+     id="metadata5093">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-54.999985,-941.36218)"
+     id="layer1">
+    <g
+       id="generic-md-3"
+       transform="translate(-180,480)">
+      <g
+         id="g6358">
+        <rect
+           style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#3a3836;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.18501282;marker:none;enable-background:accumulate"
+           id="rect3455"
+           width="50"
+           height="18"
+           x="234.99998"
+           y="461.36218"
+           ry="2.9999888"
+           rx="2.9999888" />
+        <rect
+           y="462.36218"
+           x="235.99998"
+           height="16.000008"
+           width="48"
+           id="rect3457"
+           style="color:#3a3836;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.20398235;marker:none;enable-background:accumulate"
+           ry="1.9999888"
+           rx="1.9999888" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/styles/bright-v8.json
+++ b/styles/bright-v8.json
@@ -3240,7 +3240,7 @@
                     "Arial Unicode MS Bold"
                 ],
                 "text-size": 11,
-                "icon-image": "motorway-{reflen}",
+                "icon-image": "motorway_{reflen}",
                 "symbol-placement": {
                     "base": 1,
                     "stops": [


### PR DESCRIPTION
- Add motorway icons for satellite hybrid (closes https://github.com/mapbox/mapbox-gl-styles/issues/291)
- Update bright reference to motorway icons (closes https://github.com/mapbox/mapbox-gl-styles/issues/290)

/cc @samanpwbb @peterqliu 