### PR TITLE
Script to convert studio style -> machine style

### DIFF
--- a/machinify.js
+++ b/machinify.js
@@ -21,11 +21,6 @@ fs.readFile(inputFile, encoding='utf8', function(err, data){
 	input.sprite = "mapbox://sprites/mapbox/"+styleName;
 	input.glyphs = "mapbox://fonts/mapbox/{fontstack}/{range}.pbf";
 
-	//remove layer interactivity
-	input.layers.forEach(function(layer){
-		delete layer.interactive
-	})
-
 	//name output file after style title
 	fs.writeFileSync(styleName+'.json', JSON.stringify(input, null, 2))
 })

--- a/machinify.js
+++ b/machinify.js
@@ -1,0 +1,31 @@
+var fs = require('fs')
+
+//name of file downloaded from Studio, taken from CLI
+var inputFile = process.argv[2];
+
+//keys to remove
+var keysToDelete = ['center', 'zoom', 'bearing', 'pitch', 'created', 'id', 'modified', 'owner', 'draft']
+
+fs.readFile(inputFile, encoding='utf8', function(err, data){
+	if (err) throw err;
+	var input = JSON.parse(data)
+
+	//remove specified keys
+	keysToDelete.forEach(function(key) {
+		delete input[key]
+	})
+	
+	var styleName = input.name.toLowerCase();
+	
+	//point sprite and glyphs to mapbox, instead of style author
+	input.sprite = "mapbox://sprites/mapbox/"+styleName;
+	input.glyphs = "mapbox://fonts/mapbox/{fontstack}/{range}.pbf";
+
+	//remove layer interactivity
+	input.layers.forEach(function(layer){
+		delete layer.interactive
+	})
+
+	//name output file after style title
+	fs.writeFileSync(styleName+'.json', JSON.stringify(input))
+})

--- a/machinify.js
+++ b/machinify.js
@@ -27,5 +27,5 @@ fs.readFile(inputFile, encoding='utf8', function(err, data){
 	})
 
 	//name output file after style title
-	fs.writeFileSync(styleName+'.json', JSON.stringify(input))
+	fs.writeFileSync(styleName+'.json', JSON.stringify(input, null, 2))
 })


### PR DESCRIPTION
Solves https://github.com/mapbox/mapbox-gl-styles/issues/284 and https://github.com/mapbox/mapbox-gl-styles/issues/287.

Specifically, this script:
- Removes [a set of keys](https://github.com/mapbox/mapbox-gl-styles/compare/machine-script?expand=1#diff-cddaa46d156cd7ac4179b6e37c13358eR7) Studio uses, but we don't need in the style
- [Renames `sprite` and `glyph` fields](https://github.com/mapbox/mapbox-gl-styles/compare/machine-script?expand=1#diff-cddaa46d156cd7ac4179b6e37c13358eR20) to the user `mapbox`, and the sprite field to the lowercase form of the current stylesheet `title` (assumes the title is already formatted correctly).
- [Creates an output json](https://github.com/mapbox/mapbox-gl-styles/compare/machine-script?expand=1#diff-cddaa46d156cd7ac4179b6e37c13358eR30) of the lowercased title (again, assuming the title is properly formatted). **This will overwrite existing files of the same name, without warning.**

Run this via `node machinify.js <input json name>`

cc/ @nickidlugash @samanpwbb @amyleew 
