### PR TITLE
prep patch release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.1.1
+
+- Fix incorrect default center & zoom for `bright-v9`
+
 ## v2.1.0
 
 - Add default center & zoom to latest styles

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-styles",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-gl-styles",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "mapbox gl example styles",
   "repository": {
     "type": "git",

--- a/styles/bright-v9.json
+++ b/styles/bright-v9.json
@@ -75,7 +75,7 @@
     },
     "center": [
         -118.2518,
-        50.8476
+        34.0442
     ],
     "zoom": 15,
     "sprite": "mapbox://sprites/mapbox/bright-v9",


### PR DESCRIPTION
A patch release that corrects the issue with the default zoom in `bright-v9` that was flagged by @willemarcel in https://github.com/mapbox/mapbox-gl-styles/pull/342#discussion_r378946467. 

cc/ @jseppi 